### PR TITLE
fix(core): 修复字体重载后回退default

### DIFF
--- a/src/main/java/com/sighs/apricityui/instance/Loader.java
+++ b/src/main/java/com/sighs/apricityui/instance/Loader.java
@@ -3,6 +3,7 @@ package com.sighs.apricityui.instance;
 import com.sighs.apricityui.ApricityUI;
 import com.sighs.apricityui.init.AbstractAsyncHandler;
 import com.sighs.apricityui.init.Document;
+import com.sighs.apricityui.render.FontDrawer;
 import com.sighs.apricityui.render.ImageDrawer;
 import com.sighs.apricityui.resource.Font;
 import com.sighs.apricityui.resource.HTML;
@@ -40,6 +41,7 @@ public class Loader {
         ensureAsyncHandlersInitialized();
         AbstractAsyncHandler.clearAllAndBumpGeneration();
         ImageDrawer.clearRenderTypeCache();
+        FontDrawer.clearCache();
         Font.clear();
         HTML.scan();
         Document.refreshAll();

--- a/src/main/java/com/sighs/apricityui/render/FontDrawer.java
+++ b/src/main/java/com/sighs/apricityui/render/FontDrawer.java
@@ -31,20 +31,21 @@ public class FontDrawer {
         float x = (float) position.x;
         float y = (float) position.y;
 
-        if (text.fontFamily.equals("unset")) {
+        if ("unset".equals(text.fontFamily)) {
             Client.drawDefaultFont(poseStack, text, position);
             return;
         }
 
         String key = text.toKey();
-        FontEntry entry;
-        FontEntry cache = CACHE.get(key);
-        if (cache != null) entry = cache;
-        else {
+        FontEntry entry = CACHE.get(key);
+        if (entry == null) {
             entry = rebuildTextureEntry(text);
-            CACHE.put(key, entry);
+            if (entry != null) CACHE.put(key, entry);
         }
-        if (entry == null) return;
+        if (entry == null) {
+            Client.drawDefaultFont(poseStack, text, position);
+            return;
+        }
 
         float scale = text.fontSize / Font.getBaseFontSize();
         float drawW = entry.width() * scale;
@@ -121,6 +122,17 @@ public class FontDrawer {
         } catch (Exception e) {
             return null;
         }
+    }
+
+    public static void clearCache() {
+        if (CACHE.isEmpty()) return;
+        for (FontEntry entry : CACHE.values()) {
+            if (entry == null) continue;
+            try {
+                entry.dynamicTexture().close();
+            } catch (Exception ignored) {}
+        }
+        CACHE.clear();
     }
 
     private static int argbToAbgr(int argb) {

--- a/src/main/java/com/sighs/apricityui/resource/async/style/StyleAsyncHandler.java
+++ b/src/main/java/com/sighs/apricityui/resource/async/style/StyleAsyncHandler.java
@@ -3,6 +3,7 @@ package com.sighs.apricityui.resource.async.style;
 import com.sighs.apricityui.init.AbstractAsyncHandler;
 import com.sighs.apricityui.instance.Loader;
 import com.sighs.apricityui.init.Document;
+import com.sighs.apricityui.render.FontDrawer;
 import com.sighs.apricityui.resource.CSS;
 import com.sighs.apricityui.resource.Font;
 import com.sighs.apricityui.resource.async.network.NetworkAsyncHandler;
@@ -112,6 +113,7 @@ public class StyleAsyncHandler extends AbstractAsyncHandler<StyleAsyncHandler.Ap
                 success = Font.registerFont(fontLoadedTask.fontFamily(), stream);
             } catch (IOException ignored) {}
             if (success) {
+                FontDrawer.clearCache();
                 document.reapplyStylesFromCache();
             }
             task.handle().markTaskCompleted(!success);


### PR DESCRIPTION
FontDrawer 会按文本 key 缓存纹理；字体文件异步完成前，可能先用 fallback(default) 生成并缓存。字体异步真正注册成功后，没有清理这批旧缓存，后续一直命中旧 default 纹理。并且Loader.reload() 之前也没有清空 FontDrawer 的字体纹理缓存。