### PR TITLE
feat(core): 修复通用 Element 替换成具体元素时，原来把旧对象上的监听器整包复制到了新对象上，导致的Textarea不可…

### DIFF
--- a/src/main/java/com/sighs/apricityui/event/MouseEvent.java
+++ b/src/main/java/com/sighs/apricityui/event/MouseEvent.java
@@ -2,11 +2,7 @@ package com.sighs.apricityui.event;
 
 import com.sighs.apricityui.init.*;
 import com.sighs.apricityui.render.RenderNode;
-import com.sighs.apricityui.style.Box;
-import com.sighs.apricityui.style.Cursor;
-import com.sighs.apricityui.style.Position;
-import com.sighs.apricityui.style.Size;
-import com.sighs.apricityui.style.StyleFrameCache;
+import com.sighs.apricityui.style.*;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/com/sighs/apricityui/init/Element.java
+++ b/src/main/java/com/sighs/apricityui/init/Element.java
@@ -495,7 +495,14 @@ public class Element {
             origin.children.forEach(e -> e.parentElement = element);
             element.children = new CopyOnWriteArrayList<>(origin.children);
             element.updateInlineStyle();
-            element.EventListener.addAll(origin.EventListener);
+            for (Event eventListener : origin.EventListener) {
+                // origin 在替换前是通用 Element，它构造时注册的 internal 监听器会闭包捕获旧实例。
+                // 如果直接整包复制，点击/聚焦会落到脱离 DOM 的旧对象上，导致输入链失效。
+                // 因此这里只保留外部注册的监听器；内建监听器由新实例自己的构造过程重新注册。
+                if (!eventListener.internal) {
+                    element.EventListener.add(eventListener);
+                }
+            }
             origin.document.updateElement(element);
 
             if (!element.innerText.isEmpty() && element.tagName.equals("DIV")) {

--- a/src/main/java/com/sighs/apricityui/init/Operation.java
+++ b/src/main/java/com/sighs/apricityui/init/Operation.java
@@ -1,5 +1,4 @@
 package com.sighs.apricityui.init;
-
 import com.sighs.apricityui.dev.DevTools;
 import com.sighs.apricityui.dev.ResourceManager;
 import com.sighs.apricityui.element.AbstractText;
@@ -296,4 +295,5 @@ public class Operation {
         lastModifiers = modifiers;
         return false;
     }
+
 }


### PR DESCRIPTION
…用的问题。