### PR TITLE
feat(core+mc): 优化Container中物品快捷移动的逻辑

### DIFF
--- a/common/src/main/java/com/sighs/apricityui/container/PlayerInventorySlotOrder.java
+++ b/common/src/main/java/com/sighs/apricityui/container/PlayerInventorySlotOrder.java
@@ -1,0 +1,41 @@
+package com.sighs.apricityui.container;
+
+/**
+ * 玩家背包逻辑槽位与菜单注册顺序之间的映射。
+ */
+public final class PlayerInventorySlotOrder {
+    private static final int HOTBAR_SLOT_COUNT = 9;
+
+    private PlayerInventorySlotOrder() {
+    }
+
+    /**
+     * 将菜单中的相对槽位位置映射为玩家背包逻辑索引。
+     */
+    public static int menuRelativeIndexToPlayerInventoryIndex(int menuRelativeIndex, int capacity) {
+        if (!isValidIndex(menuRelativeIndex, capacity)) return -1;
+        if (capacity <= HOTBAR_SLOT_COUNT) return menuRelativeIndex;
+
+        int mainInventorySlotCount = capacity - HOTBAR_SLOT_COUNT;
+        return menuRelativeIndex < mainInventorySlotCount
+                ? menuRelativeIndex + HOTBAR_SLOT_COUNT
+                : menuRelativeIndex - mainInventorySlotCount;
+    }
+
+    /**
+     * 将玩家背包逻辑索引映射为菜单中的相对槽位位置。
+     */
+    public static int playerInventoryIndexToMenuRelativeIndex(int playerInventoryIndex, int capacity) {
+        if (!isValidIndex(playerInventoryIndex, capacity)) return -1;
+        if (capacity <= HOTBAR_SLOT_COUNT) return playerInventoryIndex;
+
+        int mainInventorySlotCount = capacity - HOTBAR_SLOT_COUNT;
+        return playerInventoryIndex < HOTBAR_SLOT_COUNT
+                ? mainInventorySlotCount + playerInventoryIndex
+                : playerInventoryIndex - HOTBAR_SLOT_COUNT;
+    }
+
+    private static boolean isValidIndex(int index, int capacity) {
+        return capacity > 0 && index >= 0 && index < capacity;
+    }
+}

--- a/targets/fabric-1.20.1/src/main/java/com/sighs/apricityui/screen/ApricityContainerMenu.java
+++ b/targets/fabric-1.20.1/src/main/java/com/sighs/apricityui/screen/ApricityContainerMenu.java
@@ -1,5 +1,6 @@
 package com.sighs.apricityui.screen;
 
+import com.sighs.apricityui.container.PlayerInventorySlotOrder;
 import com.sighs.apricityui.container.SlotLayout;
 import com.sighs.apricityui.container.bind.ContainerBindType;
 import com.sighs.apricityui.container.datasource.ContainerDataSource;
@@ -119,8 +120,10 @@ public class ApricityContainerMenu extends AbstractContainerMenu {
 
     private void addPlayerInventorySlots(Inventory playerInventory, int capacity) {
         int normalized = Math.max(0, Math.min(ContainerBindType.PLAYER_SLOT_COUNT, capacity));
-        for (int localIndex = 0; localIndex < normalized; localIndex++) {
-            addSlot(new UiSlot(playerInventory, localIndex, 0, 0));
+        for (int menuRelativeIndex = 0; menuRelativeIndex < normalized; menuRelativeIndex++) {
+            int playerInventoryIndex = PlayerInventorySlotOrder.menuRelativeIndexToPlayerInventoryIndex(
+                    menuRelativeIndex, normalized);
+            addSlot(new UiSlot(playerInventory, playerInventoryIndex, 0, 0));
         }
     }
 
@@ -143,6 +146,17 @@ public class ApricityContainerMenu extends AbstractContainerMenu {
     public Integer resolveGlobalSlotIndex(String containerId, int localSlotIndex) {
         SlotLayout.ContainerEntry entry = layout.findContainer(containerId);
         if (entry == null) return null;
+
+        if (ContainerBindType.isPlayer(entry.bindType())) {
+            if (localSlotIndex < 0 || localSlotIndex >= entry.capacity()) return null;
+            int playerPoolCapacity = playerSlotEnd - playerSlotStart;
+            int menuRelativeIndex = PlayerInventorySlotOrder.playerInventoryIndexToMenuRelativeIndex(
+                    localSlotIndex, playerPoolCapacity);
+            if (menuRelativeIndex < 0) return null;
+            int resolved = playerSlotStart + menuRelativeIndex;
+            return resolved >= 0 && resolved < slots.size() ? resolved : null;
+        }
+
         Integer resolved = entry.resolveGlobalSlotIndex(localSlotIndex);
         if (resolved == null) return null;
         if (resolved < 0 || resolved >= slots.size()) return null;
@@ -154,8 +168,8 @@ public class ApricityContainerMenu extends AbstractContainerMenu {
         if (entry == null || entry.capacity() <= 0) return List.of();
         ArrayList<ContainerSlotRef> refs = new ArrayList<>(entry.capacity());
         for (int localIndex = 0; localIndex < entry.capacity(); localIndex++) {
-            Integer globalIndex = entry.resolveGlobalSlotIndex(localIndex);
-            if (globalIndex == null || globalIndex < 0 || globalIndex >= slots.size()) continue;
+            Integer globalIndex = resolveGlobalSlotIndex(containerId, localIndex);
+            if (globalIndex == null) continue;
             refs.add(new ContainerSlotRef(localIndex, globalIndex));
         }
         return List.copyOf(refs);

--- a/targets/fabric-1.21.1/src/main/java/com/sighs/apricityui/screen/ApricityContainerMenu.java
+++ b/targets/fabric-1.21.1/src/main/java/com/sighs/apricityui/screen/ApricityContainerMenu.java
@@ -1,5 +1,6 @@
 package com.sighs.apricityui.screen;
 
+import com.sighs.apricityui.container.PlayerInventorySlotOrder;
 import com.sighs.apricityui.container.SlotLayout;
 import com.sighs.apricityui.container.bind.ContainerBindType;
 import com.sighs.apricityui.container.datasource.ContainerDataSource;
@@ -119,8 +120,10 @@ public class ApricityContainerMenu extends AbstractContainerMenu {
 
     private void addPlayerInventorySlots(Inventory playerInventory, int capacity) {
         int normalized = Math.max(0, Math.min(ContainerBindType.PLAYER_SLOT_COUNT, capacity));
-        for (int localIndex = 0; localIndex < normalized; localIndex++) {
-            addSlot(new UiSlot(playerInventory, localIndex, 0, 0));
+        for (int menuRelativeIndex = 0; menuRelativeIndex < normalized; menuRelativeIndex++) {
+            int playerInventoryIndex = PlayerInventorySlotOrder.menuRelativeIndexToPlayerInventoryIndex(
+                    menuRelativeIndex, normalized);
+            addSlot(new UiSlot(playerInventory, playerInventoryIndex, 0, 0));
         }
     }
 
@@ -143,6 +146,17 @@ public class ApricityContainerMenu extends AbstractContainerMenu {
     public Integer resolveGlobalSlotIndex(String containerId, int localSlotIndex) {
         SlotLayout.ContainerEntry entry = layout.findContainer(containerId);
         if (entry == null) return null;
+
+        if (ContainerBindType.isPlayer(entry.bindType())) {
+            if (localSlotIndex < 0 || localSlotIndex >= entry.capacity()) return null;
+            int playerPoolCapacity = playerSlotEnd - playerSlotStart;
+            int menuRelativeIndex = PlayerInventorySlotOrder.playerInventoryIndexToMenuRelativeIndex(
+                    localSlotIndex, playerPoolCapacity);
+            if (menuRelativeIndex < 0) return null;
+            int resolved = playerSlotStart + menuRelativeIndex;
+            return resolved >= 0 && resolved < slots.size() ? resolved : null;
+        }
+
         Integer resolved = entry.resolveGlobalSlotIndex(localSlotIndex);
         if (resolved == null) return null;
         if (resolved < 0 || resolved >= slots.size()) return null;
@@ -154,8 +168,8 @@ public class ApricityContainerMenu extends AbstractContainerMenu {
         if (entry == null || entry.capacity() <= 0) return List.of();
         ArrayList<ContainerSlotRef> refs = new ArrayList<>(entry.capacity());
         for (int localIndex = 0; localIndex < entry.capacity(); localIndex++) {
-            Integer globalIndex = entry.resolveGlobalSlotIndex(localIndex);
-            if (globalIndex == null || globalIndex < 0 || globalIndex >= slots.size()) continue;
+            Integer globalIndex = resolveGlobalSlotIndex(containerId, localIndex);
+            if (globalIndex == null) continue;
             refs.add(new ContainerSlotRef(localIndex, globalIndex));
         }
         return List.copyOf(refs);

--- a/targets/forge-1.20.1/src/main/java/com/sighs/apricityui/screen/ApricityContainerMenu.java
+++ b/targets/forge-1.20.1/src/main/java/com/sighs/apricityui/screen/ApricityContainerMenu.java
@@ -1,5 +1,6 @@
 package com.sighs.apricityui.screen;
 
+import com.sighs.apricityui.container.PlayerInventorySlotOrder;
 import com.sighs.apricityui.container.SlotLayout;
 import com.sighs.apricityui.container.bind.ContainerBindType;
 import com.sighs.apricityui.container.datasource.ContainerDataSource;
@@ -120,8 +121,10 @@ public class ApricityContainerMenu extends AbstractContainerMenu {
 
     private void addPlayerInventorySlots(Inventory playerInventory, int capacity) {
         int normalized = Math.max(0, Math.min(ContainerBindType.PLAYER_SLOT_COUNT, capacity));
-        for (int localIndex = 0; localIndex < normalized; localIndex++) {
-            addSlot(new UiSlot(playerInventory, localIndex, 0, 0));
+        for (int menuRelativeIndex = 0; menuRelativeIndex < normalized; menuRelativeIndex++) {
+            int playerInventoryIndex = PlayerInventorySlotOrder.menuRelativeIndexToPlayerInventoryIndex(
+                    menuRelativeIndex, normalized);
+            addSlot(new UiSlot(playerInventory, playerInventoryIndex, 0, 0));
         }
     }
 
@@ -144,6 +147,17 @@ public class ApricityContainerMenu extends AbstractContainerMenu {
     public Integer resolveGlobalSlotIndex(String containerId, int localSlotIndex) {
         SlotLayout.ContainerEntry entry = layout.findContainer(containerId);
         if (entry == null) return null;
+
+        if (ContainerBindType.isPlayer(entry.bindType())) {
+            if (localSlotIndex < 0 || localSlotIndex >= entry.capacity()) return null;
+            int playerPoolCapacity = playerSlotEnd - playerSlotStart;
+            int menuRelativeIndex = PlayerInventorySlotOrder.playerInventoryIndexToMenuRelativeIndex(
+                    localSlotIndex, playerPoolCapacity);
+            if (menuRelativeIndex < 0) return null;
+            int resolved = playerSlotStart + menuRelativeIndex;
+            return resolved >= 0 && resolved < slots.size() ? resolved : null;
+        }
+
         Integer resolved = entry.resolveGlobalSlotIndex(localSlotIndex);
         if (resolved == null) return null;
         if (resolved < 0 || resolved >= slots.size()) return null;
@@ -155,8 +169,8 @@ public class ApricityContainerMenu extends AbstractContainerMenu {
         if (entry == null || entry.capacity() <= 0) return List.of();
         ArrayList<ContainerSlotRef> refs = new ArrayList<>(entry.capacity());
         for (int localIndex = 0; localIndex < entry.capacity(); localIndex++) {
-            Integer globalIndex = entry.resolveGlobalSlotIndex(localIndex);
-            if (globalIndex == null || globalIndex < 0 || globalIndex >= slots.size()) continue;
+            Integer globalIndex = resolveGlobalSlotIndex(containerId, localIndex);
+            if (globalIndex == null) continue;
             refs.add(new ContainerSlotRef(localIndex, globalIndex));
         }
         return List.copyOf(refs);

--- a/targets/neoforge-1.21.1/src/main/java/com/sighs/apricityui/screen/ApricityContainerMenu.java
+++ b/targets/neoforge-1.21.1/src/main/java/com/sighs/apricityui/screen/ApricityContainerMenu.java
@@ -1,5 +1,6 @@
 package com.sighs.apricityui.screen;
 
+import com.sighs.apricityui.container.PlayerInventorySlotOrder;
 import com.sighs.apricityui.container.SlotLayout;
 import com.sighs.apricityui.container.bind.ContainerBindType;
 import com.sighs.apricityui.container.datasource.ContainerDataSource;
@@ -120,8 +121,10 @@ public class ApricityContainerMenu extends AbstractContainerMenu {
 
     private void addPlayerInventorySlots(Inventory playerInventory, int capacity) {
         int normalized = Math.max(0, Math.min(ContainerBindType.PLAYER_SLOT_COUNT, capacity));
-        for (int localIndex = 0; localIndex < normalized; localIndex++) {
-            addSlot(new UiSlot(playerInventory, localIndex, 0, 0));
+        for (int menuRelativeIndex = 0; menuRelativeIndex < normalized; menuRelativeIndex++) {
+            int playerInventoryIndex = PlayerInventorySlotOrder.menuRelativeIndexToPlayerInventoryIndex(
+                    menuRelativeIndex, normalized);
+            addSlot(new UiSlot(playerInventory, playerInventoryIndex, 0, 0));
         }
     }
 
@@ -144,6 +147,17 @@ public class ApricityContainerMenu extends AbstractContainerMenu {
     public Integer resolveGlobalSlotIndex(String containerId, int localSlotIndex) {
         SlotLayout.ContainerEntry entry = layout.findContainer(containerId);
         if (entry == null) return null;
+
+        if (ContainerBindType.isPlayer(entry.bindType())) {
+            if (localSlotIndex < 0 || localSlotIndex >= entry.capacity()) return null;
+            int playerPoolCapacity = playerSlotEnd - playerSlotStart;
+            int menuRelativeIndex = PlayerInventorySlotOrder.playerInventoryIndexToMenuRelativeIndex(
+                    localSlotIndex, playerPoolCapacity);
+            if (menuRelativeIndex < 0) return null;
+            int resolved = playerSlotStart + menuRelativeIndex;
+            return resolved >= 0 && resolved < slots.size() ? resolved : null;
+        }
+
         Integer resolved = entry.resolveGlobalSlotIndex(localSlotIndex);
         if (resolved == null) return null;
         if (resolved < 0 || resolved >= slots.size()) return null;
@@ -155,8 +169,8 @@ public class ApricityContainerMenu extends AbstractContainerMenu {
         if (entry == null || entry.capacity() <= 0) return List.of();
         ArrayList<ContainerSlotRef> refs = new ArrayList<>(entry.capacity());
         for (int localIndex = 0; localIndex < entry.capacity(); localIndex++) {
-            Integer globalIndex = entry.resolveGlobalSlotIndex(localIndex);
-            if (globalIndex == null || globalIndex < 0 || globalIndex >= slots.size()) continue;
+            Integer globalIndex = resolveGlobalSlotIndex(containerId, localIndex);
+            if (globalIndex == null) continue;
             refs.add(new ContainerSlotRef(localIndex, globalIndex));
         }
         return List.copyOf(refs);

--- a/targets/neoforge-26.1/src/main/java/com/sighs/apricityui/screen/ApricityContainerMenu.java
+++ b/targets/neoforge-26.1/src/main/java/com/sighs/apricityui/screen/ApricityContainerMenu.java
@@ -1,5 +1,6 @@
 package com.sighs.apricityui.screen;
 
+import com.sighs.apricityui.container.PlayerInventorySlotOrder;
 import com.sighs.apricityui.container.SlotLayout;
 import com.sighs.apricityui.container.bind.ContainerBindType;
 import com.sighs.apricityui.container.datasource.ContainerDataSource;
@@ -120,8 +121,10 @@ public class ApricityContainerMenu extends AbstractContainerMenu {
 
     private void addPlayerInventorySlots(Inventory playerInventory, int capacity) {
         int normalized = Math.max(0, Math.min(ContainerBindType.PLAYER_SLOT_COUNT, capacity));
-        for (int localIndex = 0; localIndex < normalized; localIndex++) {
-            addSlot(new UiSlot(playerInventory, localIndex, 0, 0));
+        for (int menuRelativeIndex = 0; menuRelativeIndex < normalized; menuRelativeIndex++) {
+            int playerInventoryIndex = PlayerInventorySlotOrder.menuRelativeIndexToPlayerInventoryIndex(
+                    menuRelativeIndex, normalized);
+            addSlot(new UiSlot(playerInventory, playerInventoryIndex, 0, 0));
         }
     }
 
@@ -144,6 +147,17 @@ public class ApricityContainerMenu extends AbstractContainerMenu {
     public Integer resolveGlobalSlotIndex(String containerId, int localSlotIndex) {
         SlotLayout.ContainerEntry entry = layout.findContainer(containerId);
         if (entry == null) return null;
+
+        if (ContainerBindType.isPlayer(entry.bindType())) {
+            if (localSlotIndex < 0 || localSlotIndex >= entry.capacity()) return null;
+            int playerPoolCapacity = playerSlotEnd - playerSlotStart;
+            int menuRelativeIndex = PlayerInventorySlotOrder.playerInventoryIndexToMenuRelativeIndex(
+                    localSlotIndex, playerPoolCapacity);
+            if (menuRelativeIndex < 0) return null;
+            int resolved = playerSlotStart + menuRelativeIndex;
+            return resolved >= 0 && resolved < slots.size() ? resolved : null;
+        }
+
         Integer resolved = entry.resolveGlobalSlotIndex(localSlotIndex);
         if (resolved == null) return null;
         if (resolved < 0 || resolved >= slots.size()) return null;
@@ -155,8 +169,8 @@ public class ApricityContainerMenu extends AbstractContainerMenu {
         if (entry == null || entry.capacity() <= 0) return List.of();
         ArrayList<ContainerSlotRef> refs = new ArrayList<>(entry.capacity());
         for (int localIndex = 0; localIndex < entry.capacity(); localIndex++) {
-            Integer globalIndex = entry.resolveGlobalSlotIndex(localIndex);
-            if (globalIndex == null || globalIndex < 0 || globalIndex >= slots.size()) continue;
+            Integer globalIndex = resolveGlobalSlotIndex(containerId, localIndex);
+            if (globalIndex == null) continue;
             refs.add(new ContainerSlotRef(localIndex, globalIndex));
         }
         return List.copyOf(refs);


### PR DESCRIPTION
## Change Class

- [ ] `target-only`
- [x] `common-internal`
- [ ] `common-contract`
- [x] `cross-target-feature`
- [ ] `build-or-ci`
- [ ] `docs-only`

## Affected Targets

- [x] Forge 1.20.1
- [x] Fabric 1.20.1
- [x] Fabric 1.21.1
- [x] NeoForge 1.21.1
- [x] NeoForge 26.1
- [x] `common`

## Summary

统一玩家背包槽位在菜单中的物理注册顺序：容量大于 9 时先注册主背包槽位 `9..capacity-1`，再注册快捷栏 `0..8`。同时将 Document 的逻辑 `slot-index` 映射到实际菜单槽位，避免快捷栏显示或交互错位。

新增 `common` 内部纯整数映射工具；五个目标均已接入。未修改网络布局、`SlotLayout` 或 `quickMoveStack`。

## Cross-Version Impact

- [ ] This PR does not change `common`.
- [x] This PR changes `common` without changing its public contract.
- [ ] This PR changes a `common` contract; all affected targets are updated and validated.
- [ ] A target is intentionally not updated; the reason and tracking issue are below.

## Release Notes

此修复应包含在 Forge 1.20.1、Fabric 1.20.1 / 1.21.1、NeoForge 1.21.1 / 26.1 的发布 jar 中。

