### PR TITLE
feat(core): 新增 IntersectionObserver

### DIFF
--- a/common/src/main/java/com/sighs/apricityui/init/Document.java
+++ b/common/src/main/java/com/sighs/apricityui/init/Document.java
@@ -508,6 +508,7 @@ public class Document {
         refreshGeneration++;
         lifecycleState = LifecycleState.LOADING;
         readyState = lifecycleState.readyStateValue;
+        Window.window.clearIntersectionObservers(this);
         clearMutationObservers();
         // refresh 会重建整棵 DOM，旧元素实例全部失效，选择单元缓存一并清空
         bumpSelectionCache();
@@ -528,6 +529,7 @@ public class Document {
     public void disposeLifecycle() {
         if (lifecycleState == LifecycleState.DISPOSED) return;
         lifecycleState = LifecycleState.DISPOSED;
+        Window.window.clearIntersectionObservers(this);
         clearMutationObservers();
         // 文档关闭：停止并释放本文档全部音频（含 new Audio() 游离实例）
         com.sighs.apricityui.media.AudioEngine.releaseDocument(this);

--- a/common/src/main/java/com/sighs/apricityui/init/Window.java
+++ b/common/src/main/java/com/sighs/apricityui/init/Window.java
@@ -5,6 +5,10 @@ import com.sighs.apricityui.canvas.CanvasImageBitmap;
 import com.sighs.apricityui.canvas.CanvasImageSupport;
 import com.sighs.apricityui.canvas.DOMMatrix;
 import com.sighs.apricityui.canvas.OffscreenCanvas;
+import com.sighs.apricityui.render.CommittedGeometry;
+import com.sighs.apricityui.render.RenderNode;
+import com.sighs.apricityui.style.Interaction;
+import com.sighs.apricityui.viewport.ApricityViewport;
 import com.sighs.apricityui.loader.ClientLoader;
 import com.sighs.apricityui.loader.Loader;
 import com.sighs.apricityui.resource.async.network.NetworkAsyncHandler;
@@ -14,9 +18,19 @@ import com.sighs.apricityui.task.ClientScheduler;
 import com.sighs.apricityui.util.AuiLog;
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.NavigableSet;
+import java.util.Objects;
+import java.util.TreeSet;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -38,6 +52,7 @@ public class Window {
     private final AtomicInteger nextAnimationFrameId = new AtomicInteger(1);
     private final Performance performance = new Performance();
     private final Console console = new Console();
+    private final CopyOnWriteArrayList<IntersectionObserver> intersectionObservers = new CopyOnWriteArrayList<>();
     private final CopyOnWriteArrayList<ResizeObserver> resizeObservers = new CopyOnWriteArrayList<>();
 
     public ClientScheduler.Cancellable setTimeout(Consumer<ClientScheduler.Cancellable> runnable, int delay) {
@@ -257,6 +272,28 @@ public class Window {
         return new FetchPromise(url, contextPath);
     }
 
+    public IntersectionObserver createIntersectionObserver(Consumer<Object> callback, Element root, String rootMargin, String thresholds) {
+        Document ownerDocument = Document.getContextDocument();
+        if (root != null) {
+            if (ownerDocument != null && root.document != ownerDocument) {
+                throw new IllegalArgumentException("IntersectionObserver root must belong to the current document");
+            }
+            ownerDocument = root.document;
+        }
+        if (ownerDocument == null || !ownerDocument.isActive()) {
+            throw new IllegalStateException("IntersectionObserver must be created from an active document");
+        }
+        IntersectionObserver observer = new IntersectionObserver(
+                callback,
+                this,
+                ownerDocument,
+                root,
+                IntersectionOptions.parse(rootMargin, thresholds)
+        );
+        registerIntersectionObserver(observer);
+        return observer;
+    }
+
     public ResizeObserver createResizeObserver(Consumer<Object> callback) {
         ResizeObserver observer = new ResizeObserver(callback, this);
         resizeObservers.add(observer);
@@ -269,9 +306,44 @@ public class Window {
         dispatchEvent(event);
     }
 
+    /** Removes observers owned by a document before its DOM is rebuilt or disposed. */
+    public void clearIntersectionObservers(Document document) {
+        if (document == null) return;
+        for (IntersectionObserver observer : intersectionObservers) {
+            if (observer != null && observer.owns(document)) {
+                observer.disposeForDocument();
+            }
+        }
+    }
+
     private void cancelScheduled(Object handle) {
         if (handle instanceof ClientScheduler.Cancellable cancellable) {
             cancellable.cancel();
+        }
+    }
+
+    /** Evaluates every observer before invoking any callback from this frame. */
+    public void tickIntersectionObservers() {
+        double time = performance.now();
+        ArrayList<IntersectionDelivery> deliveries = new ArrayList<>();
+        for (IntersectionObserver observer : intersectionObservers) {
+            if (observer == null) continue;
+            List<IntersectionObserverEntry> entries = observer.collectEntries(time);
+            if (!entries.isEmpty()) {
+                deliveries.add(new IntersectionDelivery(
+                        observer.callback,
+                        observer.document,
+                        observer.documentGeneration,
+                        entries
+                ));
+            }
+        }
+        for (IntersectionDelivery delivery : deliveries) {
+            if (delivery.callback != null
+                    && delivery.document != null
+                    && delivery.document.isCurrentGeneration(delivery.documentGeneration)) {
+                Document.runWithContext(delivery.document, () -> delivery.callback.accept(delivery.entries));
+            }
         }
     }
 
@@ -283,6 +355,24 @@ public class Window {
                 resizeObservers.remove(observer);
             }
         }
+    }
+
+    private void registerIntersectionObserver(IntersectionObserver observer) {
+        if (observer != null && !intersectionObservers.contains(observer)) {
+            intersectionObservers.add(observer);
+        }
+    }
+
+    private void unregisterIntersectionObserver(IntersectionObserver observer) {
+        if (observer != null) {
+            intersectionObservers.remove(observer);
+        }
+    }
+
+    private record IntersectionDelivery(Consumer<Object> callback,
+                                        Document document,
+                                        long documentGeneration,
+                                        List<IntersectionObserverEntry> entries) {
     }
 
     private static boolean invokeWindowListener(String type, Event.ListenerRecord listener, Event event, short phase) {
@@ -613,6 +703,646 @@ public class Window {
             if (started == null) return;
             double elapsedMs = (System.nanoTime() - started) / 1_000_000.0;
             ApricityUI.LOGGER.info("{}: {}ms", key, String.format(java.util.Locale.ROOT, "%.3f", elapsedMs));
+        }
+    }
+
+    /** Immutable axis-aligned rectangle used by the internal observer state machine. */
+    public record IntersectionRect(double x, double y, double width, double height) {
+        public static final IntersectionRect ZERO = new IntersectionRect(0.0d, 0.0d, 0.0d, 0.0d);
+
+        public IntersectionRect {
+            requireFinite(x, "x");
+            requireFinite(y, "y");
+            requireFinite(width, "width");
+            requireFinite(height, "height");
+            if (width < 0.0d || height < 0.0d) {
+                throw new IllegalArgumentException("Rectangle width and height must not be negative");
+            }
+        }
+
+        public double right() {
+            return x + width;
+        }
+
+        public double bottom() {
+            return y + height;
+        }
+
+        public boolean hasArea() {
+            return width > 0.0d && height > 0.0d;
+        }
+
+        public double area() {
+            return hasArea() ? width * height : 0.0d;
+        }
+
+        public IntersectionRect expand(double top, double right, double bottom, double left) {
+            requireFinite(top, "top");
+            requireFinite(right, "right");
+            requireFinite(bottom, "bottom");
+            requireFinite(left, "left");
+            return new IntersectionRect(
+                    x - left,
+                    y - top,
+                    Math.max(0.0d, width + left + right),
+                    Math.max(0.0d, height + top + bottom)
+            );
+        }
+
+        /**
+         * Calculates a closed-rectangle intersection. Shared edges and points
+         * remain intersections with their original coordinate.
+         */
+        public static Intersection intersect(IntersectionRect first, IntersectionRect second) {
+            if (first == null || second == null) return Intersection.NONE;
+            double left = Math.max(first.x, second.x);
+            double top = Math.max(first.y, second.y);
+            double right = Math.min(first.right(), second.right());
+            double bottom = Math.min(first.bottom(), second.bottom());
+            if (left > right || top > bottom) return Intersection.NONE;
+            return new Intersection(true, new IntersectionRect(left, top, right - left, bottom - top));
+        }
+
+        private static void requireFinite(double value, String name) {
+            if (!Double.isFinite(value)) {
+                throw new IllegalArgumentException(name + " must be finite");
+            }
+        }
+
+        public record Intersection(boolean intersects, IntersectionRect rect) {
+            private static final Intersection NONE = new Intersection(false, ZERO);
+
+            public Intersection {
+                rect = Objects.requireNonNull(rect, "rect");
+            }
+        }
+    }
+
+    /** Normalized root-margin and threshold configuration for an observer. */
+    public static final class IntersectionOptions {
+        private static final Pattern MARGIN_TOKEN = Pattern.compile(
+                "([+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+))(px|%)",
+                Pattern.CASE_INSENSITIVE
+        );
+        private static final RootMargin ZERO_MARGIN = new RootMargin(
+                new MarginValue(0.0d, Unit.PX),
+                new MarginValue(0.0d, Unit.PX),
+                new MarginValue(0.0d, Unit.PX),
+                new MarginValue(0.0d, Unit.PX)
+        );
+        private static final IntersectionOptions DEFAULTS = new IntersectionOptions(ZERO_MARGIN, List.of(0.0d));
+
+        private final RootMargin rootMargin;
+        private final List<Double> thresholds;
+
+        public IntersectionOptions(String rootMargin, Collection<? extends Number> thresholds) {
+            this(parseRootMargin(rootMargin), normalizeThresholds(thresholds));
+        }
+
+        private IntersectionOptions(RootMargin rootMargin, List<Double> thresholds) {
+            this.rootMargin = rootMargin;
+            this.thresholds = thresholds;
+        }
+
+        public static IntersectionOptions defaults() {
+            return DEFAULTS;
+        }
+
+        /** Parses the scalar arguments supplied by the JavaScript bridge. */
+        public static IntersectionOptions parse(String rootMargin, String thresholdValues) {
+            return new IntersectionOptions(parseRootMargin(rootMargin), parseThresholds(thresholdValues));
+        }
+
+        /** Returns the four-value canonical root-margin string. */
+        public String rootMargin() {
+            return rootMargin.toString();
+        }
+
+        public List<Double> thresholds() {
+            return thresholds;
+        }
+
+        /** Applies root margin; percentages on every side resolve against root width. */
+        public IntersectionRect expandRootBounds(IntersectionRect rootBounds) {
+            return rootBounds == null ? null : rootMargin.expand(rootBounds);
+        }
+
+        private static RootMargin parseRootMargin(String source) {
+            if (source == null) return ZERO_MARGIN;
+            String trimmed = source.trim();
+            if (trimmed.isEmpty()) {
+                throw new IllegalArgumentException("rootMargin must contain one to four px or % values");
+            }
+            String[] tokens = trimmed.split("\\s+");
+            if (tokens.length > 4) {
+                throw new IllegalArgumentException("rootMargin must contain one to four values");
+            }
+            ArrayList<MarginValue> values = new ArrayList<>(tokens.length);
+            for (String token : tokens) {
+                values.add(parseMarginValue(token));
+            }
+            return switch (values.size()) {
+                case 1 -> new RootMargin(values.get(0), values.get(0), values.get(0), values.get(0));
+                case 2 -> new RootMargin(values.get(0), values.get(1), values.get(0), values.get(1));
+                case 3 -> new RootMargin(values.get(0), values.get(1), values.get(2), values.get(1));
+                case 4 -> new RootMargin(values.get(0), values.get(1), values.get(2), values.get(3));
+                default -> throw new IllegalArgumentException("rootMargin must contain one to four values");
+            };
+        }
+
+        private static MarginValue parseMarginValue(String token) {
+            Matcher matcher = MARGIN_TOKEN.matcher(token == null ? "" : token.trim());
+            if (!matcher.matches()) {
+                throw new IllegalArgumentException("Unsupported rootMargin value: " + token);
+            }
+            double value;
+            try {
+                value = Double.parseDouble(matcher.group(1));
+            } catch (NumberFormatException exception) {
+                throw new IllegalArgumentException("Invalid rootMargin value: " + token, exception);
+            }
+            if (!Double.isFinite(value)) {
+                throw new IllegalArgumentException("rootMargin values must be finite");
+            }
+            Unit unit = "%".equals(matcher.group(2).toLowerCase(java.util.Locale.ROOT)) ? Unit.PERCENT : Unit.PX;
+            return new MarginValue(value == 0.0d ? 0.0d : value, unit);
+        }
+
+        private static List<Double> parseThresholds(String source) {
+            if (source == null || source.isBlank()) return List.of(0.0d);
+            String[] tokens = source.split(",", -1);
+            ArrayList<Double> values = new ArrayList<>(tokens.length);
+            for (String token : tokens) {
+                if (token.isBlank()) {
+                    throw new IllegalArgumentException("threshold values must be numbers from 0 to 1");
+                }
+                try {
+                    values.add(Double.parseDouble(token.trim()));
+                } catch (NumberFormatException exception) {
+                    throw new IllegalArgumentException("Invalid threshold value: " + token, exception);
+                }
+            }
+            return normalizeThresholds(values);
+        }
+
+        private static List<Double> normalizeThresholds(Collection<? extends Number> source) {
+            if (source == null || source.isEmpty()) return List.of(0.0d);
+            NavigableSet<Double> normalized = new TreeSet<>();
+            for (Number number : source) {
+                if (number == null) {
+                    throw new IllegalArgumentException("threshold values must not be null");
+                }
+                double value = number.doubleValue();
+                if (!Double.isFinite(value) || value < 0.0d || value > 1.0d) {
+                    throw new IllegalArgumentException("threshold values must be finite numbers from 0 to 1");
+                }
+                normalized.add(value == 0.0d ? 0.0d : value);
+            }
+            return List.copyOf(normalized);
+        }
+
+        private record RootMargin(MarginValue top, MarginValue right, MarginValue bottom, MarginValue left) {
+            private IntersectionRect expand(IntersectionRect bounds) {
+                double rootWidth = bounds.width();
+                return bounds.expand(
+                        top.resolve(rootWidth),
+                        right.resolve(rootWidth),
+                        bottom.resolve(rootWidth),
+                        left.resolve(rootWidth)
+                );
+            }
+
+            @Override
+            public String toString() {
+                return top + " " + right + " " + bottom + " " + left;
+            }
+        }
+
+        private record MarginValue(double value, Unit unit) {
+            private double resolve(double rootWidth) {
+                return unit == Unit.PERCENT ? rootWidth * value / 100.0d : value;
+            }
+
+            @Override
+            public String toString() {
+                return format(value) + unit.suffix;
+            }
+        }
+
+        private enum Unit {
+            PX("px"),
+            PERCENT("%");
+
+            private final String suffix;
+
+            Unit(String suffix) {
+                this.suffix = suffix;
+            }
+        }
+
+        private static String format(double value) {
+            return BigDecimal.valueOf(value == 0.0d ? 0.0d : value).stripTrailingZeros().toPlainString();
+        }
+    }
+
+    /** Immutable committed geometry supplied to the internal observer engine. */
+    public record IntersectionSnapshot<T>(
+            T target,
+            double time,
+            IntersectionRect rootBounds,
+            IntersectionRect boundingClientRect,
+            List<IntersectionRect> clipBounds,
+            boolean eligible
+    ) {
+        public IntersectionSnapshot(T target,
+                                    double time,
+                                    IntersectionRect rootBounds,
+                                    IntersectionRect boundingClientRect,
+                                    List<IntersectionRect> clipBounds) {
+            this(target, time, rootBounds, boundingClientRect, clipBounds, true);
+        }
+
+        public IntersectionSnapshot {
+            target = Objects.requireNonNull(target, "target");
+            if (!Double.isFinite(time)) time = 0.0d;
+            boundingClientRect = Objects.requireNonNull(boundingClientRect, "boundingClientRect");
+            if (clipBounds == null || clipBounds.isEmpty()) {
+                clipBounds = List.of();
+            } else {
+                ArrayList<IntersectionRect> copied = new ArrayList<>(clipBounds.size());
+                for (IntersectionRect clip : clipBounds) {
+                    copied.add(Objects.requireNonNull(clip, "clipBounds must not contain null"));
+                }
+                clipBounds = List.copyOf(copied);
+            }
+        }
+    }
+
+    /** Immutable observer entry produced by {@link IntersectionObserverEngine}. */
+    public record IntersectionEntryData<T>(
+            T target,
+            double time,
+            IntersectionRect rootBounds,
+            IntersectionRect boundingClientRect,
+            IntersectionRect intersectionRect,
+            boolean isIntersecting,
+            double intersectionRatio
+    ) {
+        public IntersectionEntryData {
+            target = Objects.requireNonNull(target, "target");
+            if (!Double.isFinite(time)) time = 0.0d;
+            boundingClientRect = Objects.requireNonNull(boundingClientRect, "boundingClientRect");
+            intersectionRect = Objects.requireNonNull(intersectionRect, "intersectionRect");
+            if (!Double.isFinite(intersectionRatio) || intersectionRatio < 0.0d || intersectionRatio > 1.0d) {
+                throw new IllegalArgumentException("intersectionRatio must be a finite number from 0 to 1");
+            }
+        }
+    }
+
+    /** Stateful, runtime-neutral observer state machine used by {@link IntersectionObserver}. */
+    public static final class IntersectionObserverEngine<T> {
+        private final IntersectionOptions options;
+        private final IdentityHashMap<T, TargetState> observed = new IdentityHashMap<>();
+        private final ArrayList<T> observationOrder = new ArrayList<>();
+        private final ArrayList<IntersectionEntryData<T>> records = new ArrayList<>();
+
+        public IntersectionObserverEngine(IntersectionOptions options) {
+            this.options = options == null ? IntersectionOptions.defaults() : options;
+        }
+
+        public IntersectionOptions options() {
+            return options;
+        }
+
+        public synchronized void observe(T target) {
+            if (target == null || observed.containsKey(target)) return;
+            observed.put(target, new TargetState());
+            observationOrder.add(target);
+        }
+
+        public synchronized void unobserve(T target) {
+            if (target == null || observed.remove(target) == null) return;
+            removeIdentity(observationOrder, target);
+        }
+
+        /** Clears registrations without discarding queued records or disabling future observation. */
+        public synchronized void disconnect() {
+            observed.clear();
+            observationOrder.clear();
+        }
+
+        public synchronized boolean isObserved(T target) {
+            return target != null && observed.containsKey(target);
+        }
+
+        public synchronized List<T> observedTargets() {
+            return List.copyOf(observationOrder);
+        }
+
+        /** Evaluates all targets in deterministic observe order. */
+        public synchronized void evaluate(Function<? super T, ? extends IntersectionSnapshot<T>> snapshots) {
+            Objects.requireNonNull(snapshots, "snapshots");
+            for (T target : List.copyOf(observationOrder)) {
+                IntersectionSnapshot<T> snapshot = snapshots.apply(target);
+                if (snapshot != null) evaluateSnapshot(snapshot);
+            }
+        }
+
+        public synchronized void evaluate(IntersectionSnapshot<T> snapshot) {
+            if (snapshot != null) evaluateSnapshot(snapshot);
+        }
+
+        /** Atomically returns and clears pending entries. */
+        public synchronized List<IntersectionEntryData<T>> takeRecords() {
+            if (records.isEmpty()) return List.of();
+            List<IntersectionEntryData<T>> pending = List.copyOf(records);
+            records.clear();
+            return pending;
+        }
+
+        private void evaluateSnapshot(IntersectionSnapshot<T> snapshot) {
+            TargetState state = observed.get(snapshot.target());
+            if (state == null) return;
+
+            Evaluation evaluation = evaluateGeometry(snapshot);
+            int thresholdIndex = thresholdIndex(evaluation.ratio);
+            if (!state.initialized
+                    || state.isIntersecting != evaluation.isIntersecting
+                    || state.thresholdIndex != thresholdIndex) {
+                records.add(new IntersectionEntryData<>(
+                        snapshot.target(),
+                        snapshot.time(),
+                        evaluation.rootBounds,
+                        snapshot.boundingClientRect(),
+                        evaluation.intersectionRect,
+                        evaluation.isIntersecting,
+                        evaluation.ratio
+                ));
+            }
+            state.initialized = true;
+            state.isIntersecting = evaluation.isIntersecting;
+            state.thresholdIndex = thresholdIndex;
+        }
+
+        private Evaluation evaluateGeometry(IntersectionSnapshot<T> snapshot) {
+            IntersectionRect rawRootBounds = snapshot.rootBounds();
+            if (rawRootBounds == null) {
+                return new Evaluation(null, IntersectionRect.ZERO, false, 0.0d);
+            }
+            IntersectionRect rootBounds = options.expandRootBounds(rawRootBounds);
+            if (!snapshot.eligible()) {
+                return new Evaluation(rootBounds, IntersectionRect.ZERO, false, 0.0d);
+            }
+
+            IntersectionRect.Intersection intersection = new IntersectionRect.Intersection(
+                    true,
+                    snapshot.boundingClientRect()
+            );
+            for (IntersectionRect clip : snapshot.clipBounds()) {
+                intersection = IntersectionRect.intersect(intersection.rect(), clip);
+                if (!intersection.intersects()) {
+                    return new Evaluation(rootBounds, IntersectionRect.ZERO, false, 0.0d);
+                }
+            }
+            intersection = IntersectionRect.intersect(intersection.rect(), rootBounds);
+            boolean isIntersecting = intersection.intersects();
+            IntersectionRect intersectionRect = isIntersecting ? intersection.rect() : IntersectionRect.ZERO;
+            double targetArea = snapshot.boundingClientRect().area();
+            double ratio = targetArea == 0.0d ? (isIntersecting ? 1.0d : 0.0d)
+                    : clampRatio(intersectionRect.area() / targetArea);
+            return new Evaluation(rootBounds, intersectionRect, isIntersecting, ratio);
+        }
+
+        private int thresholdIndex(double ratio) {
+            List<Double> thresholds = options.thresholds();
+            int index = 0;
+            while (index < thresholds.size() && thresholds.get(index) <= ratio) {
+                index++;
+            }
+            return index;
+        }
+
+        private static double clampRatio(double ratio) {
+            if (!Double.isFinite(ratio) || ratio <= 0.0d) return 0.0d;
+            return Math.min(1.0d, ratio);
+        }
+
+        private static <T> void removeIdentity(List<T> values, T target) {
+            for (int index = 0; index < values.size(); index++) {
+                if (values.get(index) == target) {
+                    values.remove(index);
+                    return;
+                }
+            }
+        }
+
+        private static final class TargetState {
+            private boolean initialized;
+            private boolean isIntersecting;
+            private int thresholdIndex = -1;
+        }
+
+        private record Evaluation(
+                IntersectionRect rootBounds,
+                IntersectionRect intersectionRect,
+                boolean isIntersecting,
+                double ratio
+        ) {
+        }
+    }
+
+    /** Runtime-facing observer, exposed to JavaScript through the global bridge. */
+    public static final class IntersectionObserver {
+        private final Consumer<Object> callback;
+        private final Window owner;
+        private final IntersectionOptions options;
+        private final IntersectionObserverEngine<Element> engine;
+        private Document document;
+        private long documentGeneration;
+        private Element root;
+
+        private IntersectionObserver(Consumer<Object> callback,
+                                     Window owner,
+                                     Document document,
+                                     Element root,
+                                     IntersectionOptions options) {
+            this.callback = callback;
+            this.owner = owner;
+            this.document = document;
+            this.documentGeneration = document == null ? -1L : document.getRefreshGeneration();
+            this.root = root;
+            this.options = options == null ? IntersectionOptions.defaults() : options;
+            this.engine = new IntersectionObserverEngine<>(this.options);
+        }
+
+        public Element getRoot() {
+            return root;
+        }
+
+        public String getRootMargin() {
+            return options.rootMargin();
+        }
+
+        public List<Double> getThresholds() {
+            return options.thresholds();
+        }
+
+        public void observe(Element target) {
+            if (target == null || !isCurrentDocument() || target.document != document || !target.isConnected()) return;
+            engine.observe(target);
+            owner.registerIntersectionObserver(this);
+        }
+
+        public void unobserve(Element target) {
+            engine.unobserve(target);
+            unregisterIfIdle();
+        }
+
+        public void disconnect() {
+            engine.disconnect();
+            owner.unregisterIntersectionObserver(this);
+        }
+
+        public List<IntersectionObserverEntry> takeRecords() {
+            return toEntries(engine.takeRecords());
+        }
+
+        private boolean owns(Document candidate) {
+            return document == candidate;
+        }
+
+        private void disposeForDocument() {
+            engine.disconnect();
+            engine.takeRecords();
+            owner.unregisterIntersectionObserver(this);
+            root = null;
+            document = null;
+            documentGeneration = -1L;
+        }
+
+        private List<IntersectionObserverEntry> collectEntries(double time) {
+            if (!isCurrentDocument()) {
+                disposeForDocument();
+                return List.of();
+            }
+            for (Element target : engine.observedTargets()) {
+                if (target == null || target.document != document || !target.isConnected()) {
+                    engine.unobserve(target);
+                }
+            }
+            if (engine.observedTargets().isEmpty()) {
+                owner.unregisterIntersectionObserver(this);
+                return List.of();
+            }
+            engine.evaluate(target -> captureIntersectionSnapshot(document, root, target, time));
+            return toEntries(engine.takeRecords());
+        }
+
+        private boolean isCurrentDocument() {
+            if (document == null || !document.isCurrentGeneration(documentGeneration)) return false;
+            return root == null || root.document == document && root.isConnected();
+        }
+
+        private void unregisterIfIdle() {
+            if (engine.observedTargets().isEmpty()) {
+                owner.unregisterIntersectionObserver(this);
+            }
+        }
+
+        private static List<IntersectionObserverEntry> toEntries(List<IntersectionEntryData<Element>> entries) {
+            if (entries == null || entries.isEmpty()) return List.of();
+            ArrayList<IntersectionObserverEntry> converted = new ArrayList<>(entries.size());
+            for (IntersectionEntryData<Element> entry : entries) {
+                if (entry != null) converted.add(new IntersectionObserverEntry(entry));
+            }
+            return converted;
+        }
+    }
+
+    /** JavaScript-facing entry shape. */
+    public static final class IntersectionObserverEntry {
+        public final Element target;
+        public final double time;
+        public final Element.DOMRect rootBounds;
+        public final Element.DOMRect boundingClientRect;
+        public final Element.DOMRect intersectionRect;
+        public final boolean isIntersecting;
+        public final double intersectionRatio;
+
+        private IntersectionObserverEntry(IntersectionEntryData<Element> entry) {
+            this.target = entry.target();
+            this.time = entry.time();
+            this.rootBounds = toDomRect(entry.rootBounds());
+            this.boundingClientRect = toDomRect(entry.boundingClientRect());
+            this.intersectionRect = toDomRect(entry.intersectionRect());
+            this.isIntersecting = entry.isIntersecting();
+            this.intersectionRatio = entry.intersectionRatio();
+        }
+    }
+
+    private static IntersectionSnapshot<Element> captureIntersectionSnapshot(Document document,
+                                                                               Element root,
+                                                                               Element target,
+                                                                               double time) {
+        if (document == null || !document.isActive() || target == null || target.document != document || !target.isConnected()) {
+            return null;
+        }
+        List<RenderNode> paintOrder = document.getPaintList();
+        RootGeometry rootGeometry = resolveIntersectionRootGeometry(document, root, paintOrder);
+        if (rootGeometry == null) return null;
+
+        CommittedGeometry.PaintClip targetPaintClip = CommittedGeometry.resolvePaintClip(target, paintOrder);
+        IntersectionRect targetBounds = CommittedGeometry.borderBox(target);
+        boolean eligible = rootGeometry.eligible
+                && Interaction.isDisplayed(target)
+                && targetPaintClip.painted()
+                && targetBounds != null;
+        if (targetBounds == null) targetBounds = IntersectionRect.ZERO;
+
+        ArrayList<IntersectionRect> clips = new ArrayList<>();
+        appendIntersectionClips(clips, rootGeometry.ancestorClips, null);
+        appendIntersectionClips(clips, targetPaintClip.clips(), root);
+        return new IntersectionSnapshot<>(target, time, rootGeometry.bounds, targetBounds, clips, eligible);
+    }
+
+    private static RootGeometry resolveIntersectionRootGeometry(Document document,
+                                                                 Element root,
+                                                                 List<RenderNode> paintOrder) {
+        if (root == null) {
+            ApricityViewport viewport = document.getViewport();
+            return new RootGeometry(
+                    new IntersectionRect(0.0d, 0.0d, viewport.layoutWidth(), viewport.layoutHeight()),
+                    List.of(),
+                    true
+            );
+        }
+        if (root.document != document || !root.isConnected()) return null;
+        CommittedGeometry.PaintClip rootPaintClip = CommittedGeometry.resolvePaintClip(root, paintOrder);
+        IntersectionRect rootBounds = Interaction.clipsOverflow(root.getComputedStyle())
+                ? CommittedGeometry.overflowClip(root)
+                : CommittedGeometry.borderBox(root);
+        if (rootBounds == null) rootBounds = IntersectionRect.ZERO;
+        return new RootGeometry(rootBounds, rootPaintClip.clips(), Interaction.isDisplayed(root) && rootPaintClip.painted());
+    }
+
+    private static void appendIntersectionClips(List<IntersectionRect> output,
+                                                List<Element> elements,
+                                                Element excluded) {
+        if (output == null || elements == null || elements.isEmpty()) return;
+        for (Element element : elements) {
+            if (element == null || element == excluded) continue;
+            IntersectionRect bounds = CommittedGeometry.overflowClip(element);
+            if (bounds != null) output.add(bounds);
+        }
+    }
+
+    private static Element.DOMRect toDomRect(IntersectionRect rect) {
+        return rect == null ? null : new Element.DOMRect(rect.x(), rect.y(), rect.width(), rect.height());
+    }
+
+    private record RootGeometry(IntersectionRect bounds, List<Element> ancestorClips, boolean eligible) {
+        private RootGeometry {
+            ancestorClips = ancestorClips == null ? List.of() : List.copyOf(ancestorClips);
         }
     }
 

--- a/common/src/main/java/com/sighs/apricityui/init/Window.java
+++ b/common/src/main/java/com/sighs/apricityui/init/Window.java
@@ -272,13 +272,40 @@ public class Window {
         return new FetchPromise(url, contextPath);
     }
 
-    public IntersectionObserver createIntersectionObserver(Consumer<Object> callback, Element root, String rootMargin, String thresholds) {
+    /** Backwards-compatible Java entry point using the original four arguments. */
+    public IntersectionObserver createIntersectionObserver(Consumer<Object> callback,
+                                                            Element root,
+                                                            String rootMargin,
+                                                            String thresholds) {
+        return createIntersectionObserver(callback, (Object) root, rootMargin, null, thresholds, 0L, false);
+    }
+
+    /** Creates an observer with the full IntersectionObserverInit option set. */
+    public IntersectionObserver createIntersectionObserver(Consumer<Object> callback,
+                                                            Object root,
+                                                            String rootMargin,
+                                                            String scrollMargin,
+                                                            String thresholds,
+                                                            long delay,
+                                                            boolean trackVisibility) {
+        if (callback == null) {
+            throw new NullPointerException("IntersectionObserver callback must not be null");
+        }
+        if (root != null && !(root instanceof Element) && !(root instanceof Document)) {
+            throw new IllegalArgumentException("IntersectionObserver root must be an Element, Document, or null");
+        }
+
         Document ownerDocument = Document.getContextDocument();
-        if (root != null) {
-            if (ownerDocument != null && root.document != ownerDocument) {
+        if (root instanceof Element elementRoot) {
+            if (ownerDocument != null && elementRoot.document != ownerDocument) {
                 throw new IllegalArgumentException("IntersectionObserver root must belong to the current document");
             }
-            ownerDocument = root.document;
+            ownerDocument = elementRoot.document;
+        } else if (root instanceof Document documentRoot) {
+            if (ownerDocument != null && documentRoot != ownerDocument) {
+                throw new IllegalArgumentException("IntersectionObserver root must belong to the current document");
+            }
+            ownerDocument = documentRoot;
         }
         if (ownerDocument == null || !ownerDocument.isActive()) {
             throw new IllegalStateException("IntersectionObserver must be created from an active document");
@@ -288,7 +315,7 @@ public class Window {
                 this,
                 ownerDocument,
                 root,
-                IntersectionOptions.parse(rootMargin, thresholds)
+                IntersectionOptions.parse(rootMargin, scrollMargin, thresholds, delay, trackVisibility)
         );
         registerIntersectionObserver(observer);
         return observer;
@@ -339,10 +366,16 @@ public class Window {
             }
         }
         for (IntersectionDelivery delivery : deliveries) {
-            if (delivery.callback != null
-                    && delivery.document != null
-                    && delivery.document.isCurrentGeneration(delivery.documentGeneration)) {
+            if (delivery.callback == null
+                    || delivery.document == null
+                    || !delivery.document.isCurrentGeneration(delivery.documentGeneration)) {
+                continue;
+            }
+            try {
                 Document.runWithContext(delivery.document, () -> delivery.callback.accept(delivery.entries));
+            } catch (RuntimeException exception) {
+                // One observer callback must not prevent other observers from being notified.
+                ApricityUI.LOGGER.error("[AUI IntersectionObserver] callback failed", exception);
             }
         }
     }
@@ -781,7 +814,7 @@ public class Window {
     /** Normalized root-margin and threshold configuration for an observer. */
     public static final class IntersectionOptions {
         private static final Pattern MARGIN_TOKEN = Pattern.compile(
-                "([+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+))(px|%)",
+                "([+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+))(px|%|cm|mm|q|in|pc|pt)?",
                 Pattern.CASE_INSENSITIVE
         );
         private static final RootMargin ZERO_MARGIN = new RootMargin(
@@ -790,27 +823,63 @@ public class Window {
                 new MarginValue(0.0d, Unit.PX),
                 new MarginValue(0.0d, Unit.PX)
         );
-        private static final IntersectionOptions DEFAULTS = new IntersectionOptions(ZERO_MARGIN, List.of(0.0d));
+        private static final IntersectionOptions DEFAULTS =
+                new IntersectionOptions(ZERO_MARGIN, ZERO_MARGIN, List.of(0.0d), 0L, false);
 
         private final RootMargin rootMargin;
+        private final RootMargin scrollMargin;
         private final List<Double> thresholds;
+        private final long delay;
+        private final boolean trackVisibility;
 
         public IntersectionOptions(String rootMargin, Collection<? extends Number> thresholds) {
-            this(parseRootMargin(rootMargin), normalizeThresholds(thresholds));
+            this(parseRootMargin(rootMargin), ZERO_MARGIN, normalizeThresholds(thresholds), 0L, false);
         }
 
-        private IntersectionOptions(RootMargin rootMargin, List<Double> thresholds) {
-            this.rootMargin = rootMargin;
-            this.thresholds = thresholds;
+        public IntersectionOptions(String rootMargin,
+                                   String scrollMargin,
+                                   Collection<? extends Number> thresholds,
+                                   long delay,
+                                   boolean trackVisibility) {
+            this(parseRootMargin(rootMargin), parseRootMargin(scrollMargin),
+                    normalizeThresholds(thresholds), normalizeDelay(delay, trackVisibility), trackVisibility);
+        }
+
+        private IntersectionOptions(RootMargin rootMargin,
+                                    RootMargin scrollMargin,
+                                    List<Double> thresholds,
+                                    long delay,
+                                    boolean trackVisibility) {
+            this.rootMargin = rootMargin == null ? ZERO_MARGIN : rootMargin;
+            this.scrollMargin = scrollMargin == null ? ZERO_MARGIN : scrollMargin;
+            this.thresholds = thresholds == null || thresholds.isEmpty() ? List.of(0.0d) : List.copyOf(thresholds);
+            this.delay = Math.max(0L, delay);
+            this.trackVisibility = trackVisibility;
+        }
+
+        private static long normalizeDelay(long delay, boolean trackVisibility) {
+            long normalized = Math.max(0L, delay);
+            return trackVisibility && normalized < 100L ? 100L : normalized;
         }
 
         public static IntersectionOptions defaults() {
             return DEFAULTS;
         }
 
-        /** Parses the scalar arguments supplied by the JavaScript bridge. */
+        /** Parses the legacy scalar arguments supplied by the JavaScript bridge. */
         public static IntersectionOptions parse(String rootMargin, String thresholdValues) {
-            return new IntersectionOptions(parseRootMargin(rootMargin), parseThresholds(thresholdValues));
+            return new IntersectionOptions(parseRootMargin(rootMargin), ZERO_MARGIN,
+                    parseThresholds(thresholdValues), 0L, false);
+        }
+
+        /** Parses the complete scalar option set supplied by the JavaScript bridge. */
+        public static IntersectionOptions parse(String rootMargin,
+                                                String scrollMargin,
+                                                String thresholdValues,
+                                                long delay,
+                                                boolean trackVisibility) {
+            return new IntersectionOptions(parseRootMargin(rootMargin), parseRootMargin(scrollMargin),
+                    parseThresholds(thresholdValues), normalizeDelay(delay, trackVisibility), trackVisibility);
         }
 
         /** Returns the four-value canonical root-margin string. */
@@ -818,54 +887,104 @@ public class Window {
             return rootMargin.toString();
         }
 
+        /** Returns the four-value canonical scroll-margin string. */
+        public String scrollMargin() {
+            return scrollMargin.toString();
+        }
+
         public List<Double> thresholds() {
             return thresholds;
         }
 
-        /** Applies root margin; percentages on every side resolve against root width. */
+        public long delay() {
+            return delay;
+        }
+
+        public boolean trackVisibility() {
+            return trackVisibility;
+        }
+
+        /** Applies root margin; percentages on every side resolve against the raw root width. */
         public IntersectionRect expandRootBounds(IntersectionRect rootBounds) {
-            return rootBounds == null ? null : rootMargin.expand(rootBounds);
+            return expandRootBounds(rootBounds, false);
+        }
+
+        /** Applies root and (when applicable) scroll margin against the raw root width. */
+        public IntersectionRect expandRootBounds(IntersectionRect rootBounds, boolean scrollableRoot) {
+            if (rootBounds == null) return null;
+            double width = rootBounds.width();
+            return rootBounds.expand(
+                    rootMargin.top.resolve(width) + (scrollableRoot ? scrollMargin.top.resolve(width) : 0.0d),
+                    rootMargin.right.resolve(width) + (scrollableRoot ? scrollMargin.right.resolve(width) : 0.0d),
+                    rootMargin.bottom.resolve(width) + (scrollableRoot ? scrollMargin.bottom.resolve(width) : 0.0d),
+                    rootMargin.left.resolve(width) + (scrollableRoot ? scrollMargin.left.resolve(width) : 0.0d)
+            );
+        }
+
+        /** Applies scroll margin to one raw scrollport rectangle. */
+        public IntersectionRect expandScrollBounds(IntersectionRect scrollBounds) {
+            return scrollBounds == null ? null : scrollMargin.expand(scrollBounds);
         }
 
         private static RootMargin parseRootMargin(String source) {
-            if (source == null) return ZERO_MARGIN;
-            String trimmed = source.trim();
-            if (trimmed.isEmpty()) {
-                throw new IllegalArgumentException("rootMargin must contain one to four px or % values");
-            }
-            String[] tokens = trimmed.split("\\s+");
+            if (source == null || source.trim().isEmpty()) return ZERO_MARGIN;
+            String[] tokens = source.trim().split("\\s+");
             if (tokens.length > 4) {
-                throw new IllegalArgumentException("rootMargin must contain one to four values");
+                throw new IllegalArgumentException("margin must contain one to four values");
             }
             ArrayList<MarginValue> values = new ArrayList<>(tokens.length);
-            for (String token : tokens) {
-                values.add(parseMarginValue(token));
-            }
+            for (String token : tokens) values.add(parseMarginValue(token));
             return switch (values.size()) {
                 case 1 -> new RootMargin(values.get(0), values.get(0), values.get(0), values.get(0));
                 case 2 -> new RootMargin(values.get(0), values.get(1), values.get(0), values.get(1));
                 case 3 -> new RootMargin(values.get(0), values.get(1), values.get(2), values.get(1));
                 case 4 -> new RootMargin(values.get(0), values.get(1), values.get(2), values.get(3));
-                default -> throw new IllegalArgumentException("rootMargin must contain one to four values");
+                default -> ZERO_MARGIN;
             };
         }
 
         private static MarginValue parseMarginValue(String token) {
             Matcher matcher = MARGIN_TOKEN.matcher(token == null ? "" : token.trim());
             if (!matcher.matches()) {
-                throw new IllegalArgumentException("Unsupported rootMargin value: " + token);
+                throw new IllegalArgumentException("Unsupported margin value: " + token);
             }
             double value;
             try {
                 value = Double.parseDouble(matcher.group(1));
             } catch (NumberFormatException exception) {
-                throw new IllegalArgumentException("Invalid rootMargin value: " + token, exception);
+                throw new IllegalArgumentException("Invalid margin value: " + token, exception);
             }
             if (!Double.isFinite(value)) {
-                throw new IllegalArgumentException("rootMargin values must be finite");
+                throw new IllegalArgumentException("margin values must be finite");
             }
-            Unit unit = "%".equals(matcher.group(2).toLowerCase(java.util.Locale.ROOT)) ? Unit.PERCENT : Unit.PX;
-            return new MarginValue(value == 0.0d ? 0.0d : value, unit);
+            String suffix = matcher.group(2);
+            if (suffix == null || suffix.isEmpty()) {
+                if (value != 0.0d) {
+                    throw new IllegalArgumentException("Unitless margin values must be zero: " + token);
+                }
+                return new MarginValue(0.0d, Unit.PX);
+            }
+            String normalized = suffix.toLowerCase(java.util.Locale.ROOT);
+            if ("%".equals(normalized)) return new MarginValue(normalizeZero(value), Unit.PERCENT);
+            return new MarginValue(convertAbsoluteLength(value, normalized), Unit.PX);
+        }
+
+        private static double convertAbsoluteLength(double value, String unit) {
+            double factor = switch (unit) {
+                case "px" -> 1.0d;
+                case "in" -> 96.0d;
+                case "cm" -> 96.0d / 2.54d;
+                case "mm" -> 96.0d / 25.4d;
+                case "q" -> 96.0d / 101.6d;
+                case "pt" -> 96.0d / 72.0d;
+                case "pc" -> 16.0d;
+                default -> throw new IllegalArgumentException("Unsupported margin unit: " + unit);
+            };
+            return normalizeZero(value * factor);
+        }
+
+        private static double normalizeZero(double value) {
+            return value == 0.0d ? 0.0d : value;
         }
 
         private static List<Double> parseThresholds(String source) {
@@ -952,29 +1071,65 @@ public class Window {
             IntersectionRect rootBounds,
             IntersectionRect boundingClientRect,
             List<IntersectionRect> clipBounds,
-            boolean eligible
+            List<IntersectionRect> scrollClipBounds,
+            boolean rootScrollable,
+            boolean eligible,
+            boolean visible
     ) {
         public IntersectionSnapshot(T target,
                                     double time,
                                     IntersectionRect rootBounds,
                                     IntersectionRect boundingClientRect,
                                     List<IntersectionRect> clipBounds) {
-            this(target, time, rootBounds, boundingClientRect, clipBounds, true);
+            this(target, time, rootBounds, boundingClientRect, clipBounds, List.of(), false, true, true);
+        }
+
+        /** Backwards-compatible constructor retaining the old explicit eligibility flag. */
+        public IntersectionSnapshot(T target,
+                                    double time,
+                                    IntersectionRect rootBounds,
+                                    IntersectionRect boundingClientRect,
+                                    List<IntersectionRect> clipBounds,
+                                    boolean eligible) {
+            this(target, time, rootBounds, boundingClientRect, clipBounds, List.of(), false, eligible, true);
+        }
+
+        public IntersectionSnapshot(T target,
+                                    double time,
+                                    IntersectionRect rootBounds,
+                                    IntersectionRect boundingClientRect,
+                                    List<IntersectionRect> clipBounds,
+                                    boolean eligible,
+                                    boolean visible) {
+            this(target, time, rootBounds, boundingClientRect, clipBounds, List.of(), false, eligible, visible);
+        }
+
+        public IntersectionSnapshot(T target,
+                                    double time,
+                                    IntersectionRect rootBounds,
+                                    IntersectionRect boundingClientRect,
+                                    List<IntersectionRect> clipBounds,
+                                    List<IntersectionRect> scrollClipBounds,
+                                    boolean eligible,
+                                    boolean visible) {
+            this(target, time, rootBounds, boundingClientRect, clipBounds, scrollClipBounds, false, eligible, visible);
         }
 
         public IntersectionSnapshot {
             target = Objects.requireNonNull(target, "target");
             if (!Double.isFinite(time)) time = 0.0d;
             boundingClientRect = Objects.requireNonNull(boundingClientRect, "boundingClientRect");
-            if (clipBounds == null || clipBounds.isEmpty()) {
-                clipBounds = List.of();
-            } else {
-                ArrayList<IntersectionRect> copied = new ArrayList<>(clipBounds.size());
-                for (IntersectionRect clip : clipBounds) {
-                    copied.add(Objects.requireNonNull(clip, "clipBounds must not contain null"));
-                }
-                clipBounds = List.copyOf(copied);
+            clipBounds = copyRectList(clipBounds, "clipBounds");
+            scrollClipBounds = copyRectList(scrollClipBounds, "scrollClipBounds");
+        }
+
+        private static List<IntersectionRect> copyRectList(List<IntersectionRect> source, String name) {
+            if (source == null || source.isEmpty()) return List.of();
+            ArrayList<IntersectionRect> copied = new ArrayList<>(source.size());
+            for (IntersectionRect rect : source) {
+                copied.add(Objects.requireNonNull(rect, name + " must not contain null"));
             }
+            return List.copyOf(copied);
         }
     }
 
@@ -986,8 +1141,21 @@ public class Window {
             IntersectionRect boundingClientRect,
             IntersectionRect intersectionRect,
             boolean isIntersecting,
+            boolean isVisible,
             double intersectionRatio
     ) {
+        /** Backwards-compatible constructor for callers that do not track visibility. */
+        public IntersectionEntryData(T target,
+                                     double time,
+                                     IntersectionRect rootBounds,
+                                     IntersectionRect boundingClientRect,
+                                     IntersectionRect intersectionRect,
+                                     boolean isIntersecting,
+                                     double intersectionRatio) {
+            this(target, time, rootBounds, boundingClientRect, intersectionRect,
+                    isIntersecting, false, intersectionRatio);
+        }
+
         public IntersectionEntryData {
             target = Objects.requireNonNull(target, "target");
             if (!Double.isFinite(time)) time = 0.0d;
@@ -1064,53 +1232,99 @@ public class Window {
             TargetState state = observed.get(snapshot.target());
             if (state == null) return;
 
+            double time = snapshot.time();
+            if (state.initialized && options.delay() > 0L
+                    && Double.isFinite(state.lastUpdateTime)
+                    && time - state.lastUpdateTime < options.delay()) {
+                // Keep the previous delivered state intact. A later evaluation
+                // will deliver the newest geometry once the interval expires.
+                return;
+            }
+            // The delay is measured between processing opportunities, not only
+            // between entries that happened to cross a threshold.
+            state.lastUpdateTime = time;
+
             Evaluation evaluation = evaluateGeometry(snapshot);
             int thresholdIndex = thresholdIndex(evaluation.ratio);
-            if (!state.initialized
+            boolean changed = !state.initialized
                     || state.isIntersecting != evaluation.isIntersecting
-                    || state.thresholdIndex != thresholdIndex) {
+                    || state.thresholdIndex != thresholdIndex
+                    || state.isVisible != evaluation.isVisible;
+            if (changed) {
                 records.add(new IntersectionEntryData<>(
                         snapshot.target(),
-                        snapshot.time(),
+                        time,
                         evaluation.rootBounds,
                         snapshot.boundingClientRect(),
                         evaluation.intersectionRect,
                         evaluation.isIntersecting,
+                        evaluation.isVisible,
                         evaluation.ratio
                 ));
+                state.lastUpdateTime = time;
             }
             state.initialized = true;
             state.isIntersecting = evaluation.isIntersecting;
+            state.isVisible = evaluation.isVisible;
             state.thresholdIndex = thresholdIndex;
         }
 
         private Evaluation evaluateGeometry(IntersectionSnapshot<T> snapshot) {
             IntersectionRect rawRootBounds = snapshot.rootBounds();
-            if (rawRootBounds == null) {
-                return new Evaluation(null, IntersectionRect.ZERO, false, 0.0d);
+            if (rawRootBounds == null || !snapshot.eligible()) {
+                return new Evaluation(
+                        rawRootBounds == null ? null : options.expandRootBounds(rawRootBounds, snapshot.rootScrollable()),
+                        IntersectionRect.ZERO,
+                        false,
+                        visibilityFor(snapshot),
+                        0.0d
+                );
             }
-            IntersectionRect rootBounds = options.expandRootBounds(rawRootBounds);
-            if (!snapshot.eligible()) {
-                return new Evaluation(rootBounds, IntersectionRect.ZERO, false, 0.0d);
-            }
+            IntersectionRect rootBounds = options.expandRootBounds(rawRootBounds, snapshot.rootScrollable());
+            IntersectionRect targetBounds = snapshot.boundingClientRect();
 
-            IntersectionRect.Intersection intersection = new IntersectionRect.Intersection(
-                    true,
-                    snapshot.boundingClientRect()
-            );
+            // isIntersecting is intentionally based only on target-vs-root contact.
+            // Ancestor clips affect intersectionRect/ratio, but must not erase an
+            // edge-adjacent contact with the root.
+            IntersectionRect.Intersection rootContact = IntersectionRect.intersect(targetBounds, rootBounds);
+            boolean isIntersecting = rootContact.intersects();
+
+            IntersectionRect intersectionRect = targetBounds;
+            boolean clipsIntersect = true;
             for (IntersectionRect clip : snapshot.clipBounds()) {
-                intersection = IntersectionRect.intersect(intersection.rect(), clip);
-                if (!intersection.intersects()) {
-                    return new Evaluation(rootBounds, IntersectionRect.ZERO, false, 0.0d);
+                IntersectionRect.Intersection clipped = IntersectionRect.intersect(intersectionRect, clip);
+                if (!clipped.intersects()) {
+                    clipsIntersect = false;
+                    break;
+                }
+                intersectionRect = clipped.rect();
+            }
+            if (clipsIntersect) {
+                for (IntersectionRect scrollClip : snapshot.scrollClipBounds()) {
+                    IntersectionRect expanded = options.expandScrollBounds(scrollClip);
+                    IntersectionRect.Intersection clipped = IntersectionRect.intersect(intersectionRect, expanded);
+                    if (!clipped.intersects()) {
+                        clipsIntersect = false;
+                        break;
+                    }
+                    intersectionRect = clipped.rect();
                 }
             }
-            intersection = IntersectionRect.intersect(intersection.rect(), rootBounds);
-            boolean isIntersecting = intersection.intersects();
-            IntersectionRect intersectionRect = isIntersecting ? intersection.rect() : IntersectionRect.ZERO;
-            double targetArea = snapshot.boundingClientRect().area();
+            if (clipsIntersect) {
+                IntersectionRect.Intersection clippedRoot = IntersectionRect.intersect(intersectionRect, rootBounds);
+                if (clippedRoot.intersects()) intersectionRect = clippedRoot.rect();
+                else clipsIntersect = false;
+            }
+            if (!clipsIntersect) intersectionRect = IntersectionRect.ZERO;
+            double targetArea = targetBounds.area();
             double ratio = targetArea == 0.0d ? (isIntersecting ? 1.0d : 0.0d)
                     : clampRatio(intersectionRect.area() / targetArea);
-            return new Evaluation(rootBounds, intersectionRect, isIntersecting, ratio);
+            return new Evaluation(rootBounds, intersectionRect, isIntersecting,
+                    visibilityFor(snapshot), ratio);
+        }
+
+        private boolean visibilityFor(IntersectionSnapshot<T> snapshot) {
+            return options.trackVisibility() && snapshot.eligible() && snapshot.visible();
         }
 
         private int thresholdIndex(double ratio) {
@@ -1139,13 +1353,16 @@ public class Window {
         private static final class TargetState {
             private boolean initialized;
             private boolean isIntersecting;
+            private boolean isVisible;
             private int thresholdIndex = -1;
+            private double lastUpdateTime = Double.NaN;
         }
 
         private record Evaluation(
                 IntersectionRect rootBounds,
                 IntersectionRect intersectionRect,
                 boolean isIntersecting,
+                boolean isVisible,
                 double ratio
         ) {
         }
@@ -1159,12 +1376,12 @@ public class Window {
         private final IntersectionObserverEngine<Element> engine;
         private Document document;
         private long documentGeneration;
-        private Element root;
+        private Object root;
 
         private IntersectionObserver(Consumer<Object> callback,
                                      Window owner,
                                      Document document,
-                                     Element root,
+                                     Object root,
                                      IntersectionOptions options) {
             this.callback = callback;
             this.owner = owner;
@@ -1175,7 +1392,7 @@ public class Window {
             this.engine = new IntersectionObserverEngine<>(this.options);
         }
 
-        public Element getRoot() {
+        public Object getRoot() {
             return root;
         }
 
@@ -1183,12 +1400,27 @@ public class Window {
             return options.rootMargin();
         }
 
+        public String getScrollMargin() {
+            return options.scrollMargin();
+        }
+
         public List<Double> getThresholds() {
             return options.thresholds();
         }
 
+        public long getDelay() {
+            return options.delay();
+        }
+
+        public boolean getTrackVisibility() {
+            return options.trackVisibility();
+        }
+
         public void observe(Element target) {
-            if (target == null || !isCurrentDocument() || target.document != document || !target.isConnected()) return;
+            if (target == null || !isCurrentDocument() || target.document != document) return;
+            // Registration is allowed before the target is connected. The next
+            // evaluation reports the initial non-intersecting state and a later
+            // insertion can then produce the normal transition.
             engine.observe(target);
             owner.registerIntersectionObserver(this);
         }
@@ -1225,11 +1457,6 @@ public class Window {
                 disposeForDocument();
                 return List.of();
             }
-            for (Element target : engine.observedTargets()) {
-                if (target == null || target.document != document || !target.isConnected()) {
-                    engine.unobserve(target);
-                }
-            }
             if (engine.observedTargets().isEmpty()) {
                 owner.unregisterIntersectionObserver(this);
                 return List.of();
@@ -1239,8 +1466,7 @@ public class Window {
         }
 
         private boolean isCurrentDocument() {
-            if (document == null || !document.isCurrentGeneration(documentGeneration)) return false;
-            return root == null || root.document == document && root.isConnected();
+            return document != null && document.isCurrentGeneration(documentGeneration);
         }
 
         private void unregisterIfIdle() {
@@ -1267,6 +1493,7 @@ public class Window {
         public final Element.DOMRect boundingClientRect;
         public final Element.DOMRect intersectionRect;
         public final boolean isIntersecting;
+        public final boolean isVisible;
         public final double intersectionRatio;
 
         private IntersectionObserverEntry(IntersectionEntryData<Element> entry) {
@@ -1276,74 +1503,170 @@ public class Window {
             this.boundingClientRect = toDomRect(entry.boundingClientRect());
             this.intersectionRect = toDomRect(entry.intersectionRect());
             this.isIntersecting = entry.isIntersecting();
+            this.isVisible = entry.isVisible();
             this.intersectionRatio = entry.intersectionRatio();
         }
     }
 
     private static IntersectionSnapshot<Element> captureIntersectionSnapshot(Document document,
-                                                                               Element root,
+                                                                               Object root,
                                                                                Element target,
                                                                                double time) {
-        if (document == null || !document.isActive() || target == null || target.document != document || !target.isConnected()) {
-            return null;
-        }
+        if (document == null || !document.isActive() || target == null) return null;
+
         List<RenderNode> paintOrder = document.getPaintList();
         RootGeometry rootGeometry = resolveIntersectionRootGeometry(document, root, paintOrder);
         if (rootGeometry == null) return null;
 
-        CommittedGeometry.PaintClip targetPaintClip = CommittedGeometry.resolvePaintClip(target, paintOrder);
-        IntersectionRect targetBounds = CommittedGeometry.borderBox(target);
-        boolean eligible = rootGeometry.eligible
-                && Interaction.isDisplayed(target)
-                && targetPaintClip.painted()
-                && targetBounds != null;
+        boolean sameDocument = target.document == document;
+        boolean connected = sameDocument && target.isConnected();
+        Element rootElement = root instanceof Element elementRoot ? elementRoot : null;
+        boolean withinRoot = rootElement == null || isSameOrDescendant(target, rootElement);
+        boolean paintCommitted = paintOrder != null && !paintOrder.isEmpty();
+        CommittedGeometry.PaintClip targetPaintClip = paintCommitted
+                ? CommittedGeometry.resolvePaintClip(target, paintOrder) : null;
+        boolean painted = targetPaintClip != null && targetPaintClip.painted();
+
+        IntersectionRect targetBounds = connected ? CommittedGeometry.borderBox(target) : null;
+        boolean hasCommittedBounds = targetBounds != null;
         if (targetBounds == null) targetBounds = IntersectionRect.ZERO;
 
+        boolean displayed = connected && Interaction.isDisplayed(target);
+        boolean eligible = rootGeometry.eligible
+                && withinRoot
+                && displayed
+                && painted
+                && hasCommittedBounds;
+        boolean visible = resolveIntersectionVisibility(target, eligible);
+
         ArrayList<IntersectionRect> clips = new ArrayList<>();
-        appendIntersectionClips(clips, rootGeometry.ancestorClips, null);
-        appendIntersectionClips(clips, targetPaintClip.clips(), root);
-        return new IntersectionSnapshot<>(target, time, rootGeometry.bounds, targetBounds, clips, eligible);
+        ArrayList<IntersectionRect> scrollClips = new ArrayList<>();
+        if (connected) {
+            // The DOM ancestor walk is the single source of geometry clips. The
+            // paint list above only tells us whether a committed border phase
+            // exists; adding its mask stack here would clip scrollports before
+            // scrollMargin has a chance to expand them.
+            appendAncestorIntersectionClips(clips, scrollClips, target, rootElement);
+        }
+        return new IntersectionSnapshot<>(
+                target,
+                time,
+                rootGeometry.bounds,
+                targetBounds,
+                clips,
+                scrollClips,
+                rootGeometry.scrollable,
+                eligible,
+                visible
+        );
     }
 
     private static RootGeometry resolveIntersectionRootGeometry(Document document,
-                                                                 Element root,
+                                                                 Object root,
                                                                  List<RenderNode> paintOrder) {
-        if (root == null) {
+        if (root == null || root instanceof Document) {
             ApricityViewport viewport = document.getViewport();
             return new RootGeometry(
                     new IntersectionRect(0.0d, 0.0d, viewport.layoutWidth(), viewport.layoutHeight()),
-                    List.of(),
-                    true
+                    true,
+                    false
             );
         }
-        if (root.document != document || !root.isConnected()) return null;
-        CommittedGeometry.PaintClip rootPaintClip = CommittedGeometry.resolvePaintClip(root, paintOrder);
-        IntersectionRect rootBounds = Interaction.clipsOverflow(root.getComputedStyle())
-                ? CommittedGeometry.overflowClip(root)
-                : CommittedGeometry.borderBox(root);
-        if (rootBounds == null) rootBounds = IntersectionRect.ZERO;
-        return new RootGeometry(rootBounds, rootPaintClip.clips(), Interaction.isDisplayed(root) && rootPaintClip.painted());
+        if (!(root instanceof Element elementRoot)) {
+            return new RootGeometry(null, false, false);
+        }
+        if (elementRoot.document != document || !elementRoot.isConnected()) {
+            // Keep the observer alive while a root is detached. A null root
+            // bounds makes the next evaluation a clean non-intersecting state.
+            return new RootGeometry(null, false, false);
+        }
+        boolean paintCommitted = paintOrder != null && !paintOrder.isEmpty();
+        CommittedGeometry.PaintClip rootPaintClip = paintCommitted
+                ? CommittedGeometry.resolvePaintClip(elementRoot, paintOrder) : null;
+        IntersectionRect rootBounds = Interaction.clipsOverflow(elementRoot.getComputedStyle())
+                ? CommittedGeometry.overflowClip(elementRoot)
+                : CommittedGeometry.borderBox(elementRoot);
+        boolean eligible = Interaction.isDisplayed(elementRoot)
+                && rootPaintClip != null
+                && rootPaintClip.painted()
+                && rootBounds != null;
+        return new RootGeometry(rootBounds, eligible, isScrollContainer(elementRoot));
     }
 
-    private static void appendIntersectionClips(List<IntersectionRect> output,
-                                                List<Element> elements,
-                                                Element excluded) {
-        if (output == null || elements == null || elements.isEmpty()) return;
-        for (Element element : elements) {
-            if (element == null || element == excluded) continue;
-            IntersectionRect bounds = CommittedGeometry.overflowClip(element);
-            if (bounds != null) output.add(bounds);
+    /** Adds overflow clips between target and an explicit root (or the document). */
+    private static void appendAncestorIntersectionClips(List<IntersectionRect> clips,
+                                                        List<IntersectionRect> scrollClips,
+                                                        Element target,
+                                                        Element root) {
+        if (target == null) return;
+        IdentityHashMap<Element, Boolean> seen = new IdentityHashMap<>();
+        Element current = target.parentElement;
+        while (current != null && current != root) {
+            if (seen.put(current, Boolean.TRUE) == null && Interaction.clipsOverflow(current.getComputedStyle())) {
+                IntersectionRect bounds = CommittedGeometry.overflowClip(current);
+                if (bounds != null) {
+                    if (isScrollContainer(current)) scrollClips.add(bounds);
+                    else clips.add(bounds);
+                }
+            }
+            current = current.parentElement;
         }
+    }
+
+    private static boolean isSameOrDescendant(Element target, Element ancestor) {
+        if (target == null || ancestor == null) return false;
+        Element current = target;
+        while (current != null) {
+            if (current == ancestor) return true;
+            current = current.parentElement;
+        }
+        return false;
+    }
+
+    private static boolean isScrollContainer(Element element) {
+        if (element == null) return false;
+        Style style = element.getComputedStyle();
+        return isScrollOverflow(Interaction.resolveOverflowX(style))
+                || isScrollOverflow(Interaction.resolveOverflowY(style));
+    }
+
+    private static boolean isScrollOverflow(String overflow) {
+        String normalized = Interaction.normalizeOverflow(overflow);
+        return !"visible".equals(normalized) && !"clip".equals(normalized);
+    }
+
+    /** Conservative visibility subset used when trackVisibility is enabled. */
+    private static boolean resolveIntersectionVisibility(Element target, boolean eligible) {
+        if (!eligible || target == null) return false;
+        for (Element current = target; current != null; current = current.parentElement) {
+            Style style = current.getComputedStyle();
+            if ("none".equals(style.display)) return false;
+            if (!Interaction.isVisible(current)) return false;
+            if (effectiveOpacity(style.opacity) < 0.999999d) return false;
+            if (hasNonNone(style.transform) || hasNonNone(style.filter) || hasNonNone(style.clipPath)) return false;
+        }
+        return true;
+    }
+
+    private static double effectiveOpacity(String raw) {
+        if (raw == null || raw.isBlank() || "unset".equalsIgnoreCase(raw.trim())) return 1.0d;
+        try {
+            double value = Double.parseDouble(raw.trim());
+            return Double.isFinite(value) ? Math.max(0.0d, value) : 0.0d;
+        } catch (NumberFormatException ignored) {
+            return 0.0d;
+        }
+    }
+
+    private static boolean hasNonNone(String value) {
+        return value != null && !value.isBlank() && !"none".equalsIgnoreCase(value.trim());
     }
 
     private static Element.DOMRect toDomRect(IntersectionRect rect) {
         return rect == null ? null : new Element.DOMRect(rect.x(), rect.y(), rect.width(), rect.height());
     }
 
-    private record RootGeometry(IntersectionRect bounds, List<Element> ancestorClips, boolean eligible) {
-        private RootGeometry {
-            ancestorClips = ancestorClips == null ? List.of() : List.copyOf(ancestorClips);
-        }
+    private record RootGeometry(IntersectionRect bounds, boolean eligible, boolean scrollable) {
     }
 
     public static class ResizeObserver {

--- a/common/src/main/java/com/sighs/apricityui/render/CommittedGeometry.java
+++ b/common/src/main/java/com/sighs/apricityui/render/CommittedGeometry.java
@@ -1,0 +1,112 @@
+package com.sighs.apricityui.render;
+
+import com.sighs.apricityui.init.Element;
+import com.sighs.apricityui.init.Window;
+import com.sighs.apricityui.layout.Box;
+import com.sighs.apricityui.layout.Position;
+import com.sighs.apricityui.layout.Size;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Shared access to layout geometry committed for the current document frame. */
+public final class CommittedGeometry {
+    private CommittedGeometry() {
+    }
+
+    public static Window.IntersectionRect borderBox(Element element) {
+        Rect rect = committedRect(element);
+        if (rect == null) return null;
+        Position position = rect.position;
+        Box box = rect.box;
+        Size size = rect.getElementSize();
+        return new Window.IntersectionRect(
+                position.x + box.getMarginLeft(),
+                position.y + box.getMarginTop(),
+                size.width(),
+                size.height()
+        );
+    }
+
+    public static Window.IntersectionRect hitTestBounds(Element element) {
+        if (element == null) return null;
+        if (!"IMG".equals(element.tagName)) return borderBox(element);
+        return bodyBox(element);
+    }
+
+    public static Window.IntersectionRect bodyBox(Element element) {
+        Rect rect = committedRect(element);
+        if (rect == null) return null;
+        Position position = rect.getBodyRectPosition();
+        Size size = rect.getBodyRectSize();
+        return new Window.IntersectionRect(position.x, position.y, size.width(), size.height());
+    }
+
+    /** The committed padding-box overflow clip, excluding active scrollbar gutters. */
+    public static Window.IntersectionRect overflowClip(Element element) {
+        Window.IntersectionRect body = bodyBox(element);
+        if (body == null) return null;
+        return new Window.IntersectionRect(
+                body.x(),
+                body.y(),
+                Math.max(0.0d, body.width() - element.getVerticalScrollbarGutter()),
+                Math.max(0.0d, body.height() - element.getHorizontalScrollbarGutter())
+        );
+    }
+
+    public static Window.IntersectionRect intersectOverflowClips(Iterable<Element> clips) {
+        if (clips == null) return null;
+        Window.IntersectionRect effective = null;
+        for (Element clip : clips) {
+            Window.IntersectionRect bounds = overflowClip(clip);
+            if (bounds == null) continue;
+            if (effective == null) {
+                effective = bounds;
+                continue;
+            }
+            Window.IntersectionRect.Intersection intersection = Window.IntersectionRect.intersect(effective, bounds);
+            if (!intersection.intersects()) return Window.IntersectionRect.ZERO;
+            effective = intersection.rect();
+        }
+        return effective;
+    }
+
+    /** Resolves the overflow-clip stack active when an element's border phase is painted. */
+    public static PaintClip resolvePaintClip(Element target, List<RenderNode> paintOrder) {
+        if (target == null || paintOrder == null || paintOrder.isEmpty()) return PaintClip.NOT_PAINTED;
+        ArrayDeque<Element> clipStack = new ArrayDeque<>();
+        for (int index = paintOrder.size() - 1; index >= 0; index--) {
+            RenderNode node = paintOrder.get(index);
+            if (node instanceof RenderNode.MaskPopNode popNode) {
+                Element clipTarget = popNode.target();
+                if (clipTarget != null) clipStack.push(clipTarget);
+                continue;
+            }
+            if (node instanceof RenderNode.MaskPushNode pushNode) {
+                if (!clipStack.isEmpty() && clipStack.peek() == pushNode.target()) {
+                    clipStack.pop();
+                }
+                continue;
+            }
+            if (node instanceof RenderNode.ElementPhaseNode phaseNode
+                    && phaseNode.target() == target
+                    && phaseNode.phase() == Base.RenderPhase.BORDER) {
+                return new PaintClip(true, List.copyOf(new ArrayList<>(clipStack)));
+            }
+        }
+        return PaintClip.NOT_PAINTED;
+    }
+
+    private static Rect committedRect(Element element) {
+        return element == null ? null : element.getRenderer().getCommittedRectIfValid();
+    }
+
+    public record PaintClip(boolean painted, List<Element> clips) {
+        private static final PaintClip NOT_PAINTED = new PaintClip(false, List.of());
+
+        public PaintClip {
+            clips = clips == null ? List.of() : List.copyOf(clips);
+        }
+    }
+}

--- a/common/src/main/java/com/sighs/apricityui/render/HitTestCache.java
+++ b/common/src/main/java/com/sighs/apricityui/render/HitTestCache.java
@@ -1,11 +1,7 @@
 package com.sighs.apricityui.render;
 
-import com.sighs.apricityui.render.Rect;
-import com.sighs.apricityui.render.RenderNode;
-import com.sighs.apricityui.layout.Box;
 import com.sighs.apricityui.style.Interaction;
 import com.sighs.apricityui.layout.Position;
-import com.sighs.apricityui.layout.Size;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -17,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import com.sighs.apricityui.init.Document;
 import com.sighs.apricityui.init.Element;
+import com.sighs.apricityui.init.Window;
 
 public final class HitTestCache {
     private final Document owner;
@@ -100,7 +97,7 @@ public final class HitTestCache {
 
             Bounds bounds = resolveCommittedBounds(element, boundsCache);
             if (!bounds.isValid()) continue;
-            Bounds clip = resolveCommittedClipBounds(clipContext, boundsCache);
+            Bounds clip = resolveCommittedClipBounds(clipContext);
             if (clip != null && clip.isEmpty()) continue;
             entries.add(new Entry(element, bounds, clip));
         }
@@ -155,7 +152,7 @@ public final class HitTestCache {
 
             Bounds bounds = resolveCommittedBounds(element, boundsCache);
             if (!bounds.isValid()) continue;
-            Bounds clip = resolveCommittedClipBounds(clipContext, boundsCache);
+            Bounds clip = resolveCommittedClipBounds(clipContext);
             if (clip != null && clip.isEmpty()) continue;
             rebuilt.add(new Entry(element, bounds, clip));
         }
@@ -189,48 +186,21 @@ public final class HitTestCache {
         Bounds cached = boundsCache.get(element);
         if (cached != null) return cached;
 
-        Rect rect = element.getRenderer().getCommittedRect();
-        if (rect == null) return Bounds.EMPTY;
-        Bounds bounds;
-        if ("IMG".equals(element.tagName)) {
-            Position position = rect.getBodyRectPosition();
-            Size size = rect.getBodyRectSize();
-            bounds = new Bounds(position.x, position.y, size.width(), size.height());
-        } else {
-            Position position = rect.position;
-            Box box = rect.box;
-            Size size = rect.getElementSize();
-            bounds = new Bounds(
-                    position.x + box.getMarginLeft(),
-                    position.y + box.getMarginTop(),
-                    size.width(),
-                    size.height()
-            );
-        }
+        Window.IntersectionRect committed = CommittedGeometry.hitTestBounds(element);
+        if (committed == null) return Bounds.EMPTY;
+        Bounds bounds = new Bounds(committed.x(), committed.y(), committed.width(), committed.height());
         boundsCache.put(element, bounds);
         return bounds;
     }
 
-    private static Bounds resolveCommittedClipBounds(ClipContext clipContext, Map<Element, Bounds> boundsCache) {
+    private static Bounds resolveCommittedClipBounds(ClipContext clipContext) {
         if (clipContext.isEmpty()) return null;
         if (clipContext.computedVersion == clipContext.version) return clipContext.result;
-        Bounds effective = null;
-        for (Element clip : clipContext.stack) {
-            Rect rect = clip.getRenderer().getCommittedRect();
-            if (rect == null) continue;
-            Position position = rect.getBodyRectPosition();
-            Size size = rect.getBodyRectSize();
-            Bounds clipBounds = new Bounds(
-                    position.x,
-                    position.y,
-                    Math.max(0, size.width() - clip.getVerticalScrollbarGutter()),
-                    Math.max(0, size.height() - clip.getHorizontalScrollbarGutter())
-            );
-            if (clipBounds.isEmpty()) return memoClip(clipContext, Bounds.EMPTY);
-            effective = effective == null ? clipBounds : effective.intersection(clipBounds);
-            if (effective.isEmpty()) return memoClip(clipContext, Bounds.EMPTY);
-        }
-        return memoClip(clipContext, effective);
+        Window.IntersectionRect effective = CommittedGeometry.intersectOverflowClips(clipContext.stack);
+        Bounds result = effective == null
+                ? null
+                : new Bounds(effective.x(), effective.y(), effective.width(), effective.height());
+        return memoClip(clipContext, result);
     }
 
     private static Bounds memoClip(ClipContext clipContext, Bounds result) {
@@ -244,28 +214,26 @@ public final class HitTestCache {
                                                Map<Element, Bounds> boundsCache,
                                                List<Entry> output) {
         if (element == null || output == null || !element.isPointerEnabled || !element.isVisible) return;
-        Rect rect = element.getRenderer().getCommittedRect();
-        if (rect == null) return;
-        Position position = rect.getBodyRectPosition();
-        Size size = rect.getBodyRectSize();
+        Window.IntersectionRect body = CommittedGeometry.bodyBox(element);
+        if (body == null) return;
         double vertical = element.getVerticalScrollbarGutter();
         double horizontal = element.getHorizontalScrollbarGutter();
-        Bounds clip = resolveCommittedClipBounds(clipContext, boundsCache);
+        Bounds clip = resolveCommittedClipBounds(clipContext);
         if (clip != null && clip.isEmpty()) return;
         if (vertical > 0) {
             Bounds bounds = new Bounds(
-                    position.x + size.width() - vertical,
-                    position.y,
+                    body.x() + body.width() - vertical,
+                    body.y(),
                     vertical,
-                    Math.max(0, size.height() - horizontal)
+                    Math.max(0, body.height() - horizontal)
             );
             if (bounds.isValid()) output.add(new Entry(element, bounds, clip));
         }
         if (horizontal > 0) {
             Bounds bounds = new Bounds(
-                    position.x,
-                    position.y + size.height() - horizontal,
-                    Math.max(0, size.width() - vertical),
+                    body.x(),
+                    body.y() + body.height() - horizontal,
+                    Math.max(0, body.width() - vertical),
                     horizontal
             );
             if (bounds.isValid()) output.add(new Entry(element, bounds, clip));

--- a/common/src/main/java/com/sighs/apricityui/task/FrameScheduler.java
+++ b/common/src/main/java/com/sighs/apricityui/task/FrameScheduler.java
@@ -36,6 +36,7 @@ public final class FrameScheduler {
             if (document == null) continue;
             document.tickFrame();
         }
+        Window.window.tickIntersectionObservers();
         Window.window.tickResizeObservers();
     }
 

--- a/common/src/main/resources/assets/apricityui/apricity/global.js
+++ b/common/src/main/resources/assets/apricityui/apricity/global.js
@@ -491,6 +491,36 @@ function __auiDecorateResizeEntries(list) {
   return out;
 }
 
+function __auiDecorateIntersectionEntries(list) {
+  if (!list) return [];
+  let out = [];
+  let size = typeof list.size === 'function' ? list.size() : (list.length || 0);
+  for (let i = 0; i < size; i++) {
+    let entry = typeof list.get === 'function' ? list.get(i) : list[i];
+    if (!entry) continue;
+    out.push({
+      target: __auiDecorateElement(entry.target),
+      time: Number(entry.time),
+      rootBounds: entry.rootBounds || null,
+      boundingClientRect: entry.boundingClientRect,
+      intersectionRect: entry.intersectionRect,
+      isIntersecting: !!entry.isIntersecting,
+      intersectionRatio: Number(entry.intersectionRatio)
+    });
+  }
+  return out;
+}
+
+function __auiDecorateIntersectionThresholds(list) {
+  if (!list) return [];
+  let out = [];
+  let size = typeof list.size === 'function' ? list.size() : (list.length || 0);
+  for (let i = 0; i < size; i++) {
+    out.push(Number(typeof list.get === 'function' ? list.get(i) : list[i]));
+  }
+  return out;
+}
+
 function __auiDecorateMutationRecords(list) {
   if (!list) return [];
   let out = [];
@@ -945,6 +975,57 @@ function ResizeObserver(callback) {
     unobserve: function(target) { nativeObserver.unobserve(__auiDecorateElement(target)); },
     disconnect: function() { nativeObserver.disconnect(); }
   };
+  return observer;
+}
+
+function IntersectionObserver(callback, options) {
+  if (typeof callback !== 'function') throw new TypeError('IntersectionObserver callback must be a function');
+  if (options == null) options = {};
+  if (typeof options !== 'object') throw new TypeError('IntersectionObserver options must be an object');
+
+  let root = options.root == null ? null : options.root;
+  if (root !== null && (!root || typeof root.getNodeType !== 'function' || root.getNodeType() !== 1)) {
+    throw new TypeError('IntersectionObserver root must be an Element or null');
+  }
+  root = root === null ? null : __auiDecorateElement(root);
+
+  let threshold = options.threshold;
+  let thresholds = null;
+  if (threshold != null) {
+    if (typeof threshold === 'number') {
+      thresholds = String(threshold);
+    } else if (typeof threshold === 'object' && typeof threshold.length === 'number') {
+      let values = [];
+      for (let i = 0; i < threshold.length; i++) values.push(String(threshold[i]));
+      thresholds = values.join(',');
+    } else {
+      throw new TypeError('IntersectionObserver threshold must be a number or array-like value');
+    }
+  }
+
+  let rootMargin = options.rootMargin == null ? null : String(options.rootMargin);
+  let nativeObserver = window.createIntersectionObserver(function(entries) {
+    callback(__auiDecorateIntersectionEntries(entries), observer);
+  }, root, rootMargin, thresholds);
+  let observer = {
+    observe: function(target) {
+      if (!target || typeof target.getNodeType !== 'function' || target.getNodeType() !== 1) {
+        throw new TypeError('IntersectionObserver target must be an Element');
+      }
+      nativeObserver.observe(__auiDecorateElement(target));
+    },
+    unobserve: function(target) {
+      if (!target || typeof target.getNodeType !== 'function' || target.getNodeType() !== 1) {
+        throw new TypeError('IntersectionObserver target must be an Element');
+      }
+      nativeObserver.unobserve(__auiDecorateElement(target));
+    },
+    disconnect: function() { nativeObserver.disconnect(); },
+    takeRecords: function() { return __auiDecorateIntersectionEntries(nativeObserver.takeRecords()); }
+  };
+  __auiInstallValueBridge(observer, 'root', () => __auiDecorateElement(nativeObserver.getRoot()));
+  __auiInstallValueBridge(observer, 'rootMargin', () => nativeObserver.getRootMargin());
+  __auiInstallValueBridge(observer, 'thresholds', () => __auiDecorateIntersectionThresholds(nativeObserver.getThresholds()));
   return observer;
 }
 

--- a/common/src/main/resources/assets/apricityui/apricity/global.js
+++ b/common/src/main/resources/assets/apricityui/apricity/global.js
@@ -505,6 +505,7 @@ function __auiDecorateIntersectionEntries(list) {
       boundingClientRect: entry.boundingClientRect,
       intersectionRect: entry.intersectionRect,
       isIntersecting: !!entry.isIntersecting,
+      isVisible: !!entry.isVisible,
       intersectionRatio: Number(entry.intersectionRatio)
     });
   }
@@ -978,54 +979,108 @@ function ResizeObserver(callback) {
   return observer;
 }
 
+function __auiNormalizeIntersectionMargin(value, name) {
+  let text = value == null ? '' : String(value).trim();
+  if (text === '') return '';
+  let tokens = text.split(/\s+/);
+  if (tokens.length > 4) throw new SyntaxError(name + ' must contain one to four values');
+  let pattern = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:px|%|cm|mm|q|in|pc|pt)?$/i;
+  for (let i = 0; i < tokens.length; i++) {
+    if (!pattern.test(tokens[i])) throw new SyntaxError('Invalid ' + name + ' value: ' + tokens[i]);
+    let unit = tokens[i].match(/(px|%|cm|mm|q|in|pc|pt)$/i);
+    if (!unit && Number(tokens[i]) !== 0) {
+      throw new SyntaxError('Unitless ' + name + ' values must be zero');
+    }
+  }
+  return text;
+}
+
+function __auiNormalizeIntersectionThreshold(value) {
+  let number = Number(value);
+  if (!isFinite(number) || number < 0 || number > 1) {
+    throw new RangeError('IntersectionObserver threshold must be a number from 0 to 1');
+  }
+  return String(number);
+}
+
+IntersectionObserver.prototype = {
+  constructor: IntersectionObserver,
+  observe: function(target) {
+    if (!target || typeof target.getNodeType !== 'function' || target.getNodeType() !== 1) {
+      throw new TypeError('IntersectionObserver target must be an Element');
+    }
+    this.__auiNativeObserver.observe(__auiDecorateElement(target));
+  },
+  unobserve: function(target) {
+    if (!target || typeof target.getNodeType !== 'function' || target.getNodeType() !== 1) {
+      throw new TypeError('IntersectionObserver target must be an Element');
+    }
+    this.__auiNativeObserver.unobserve(__auiDecorateElement(target));
+  },
+  disconnect: function() { this.__auiNativeObserver.disconnect(); },
+  takeRecords: function() {
+    return __auiDecorateIntersectionEntries(this.__auiNativeObserver.takeRecords());
+  }
+};
+
 function IntersectionObserver(callback, options) {
   if (typeof callback !== 'function') throw new TypeError('IntersectionObserver callback must be a function');
   if (options == null) options = {};
   if (typeof options !== 'object') throw new TypeError('IntersectionObserver options must be an object');
 
   let root = options.root == null ? null : options.root;
-  if (root !== null && (!root || typeof root.getNodeType !== 'function' || root.getNodeType() !== 1)) {
-    throw new TypeError('IntersectionObserver root must be an Element or null');
+  let isDocumentRoot = root === document || (root && typeof root.getDocumentElement === 'function'
+    && typeof root.getURL === 'function');
+  if (root !== null && !isDocumentRoot
+      && (!root || typeof root.getNodeType !== 'function' || root.getNodeType() !== 1)) {
+    throw new TypeError('IntersectionObserver root must be an Element, Document, or null');
   }
-  root = root === null ? null : __auiDecorateElement(root);
+  root = root === null || isDocumentRoot ? root : __auiDecorateElement(root);
 
   let threshold = options.threshold;
   let thresholds = null;
   if (threshold != null) {
     if (typeof threshold === 'number') {
-      thresholds = String(threshold);
+      thresholds = __auiNormalizeIntersectionThreshold(threshold);
     } else if (typeof threshold === 'object' && typeof threshold.length === 'number') {
       let values = [];
-      for (let i = 0; i < threshold.length; i++) values.push(String(threshold[i]));
+      for (let i = 0; i < threshold.length; i++) {
+        values.push(__auiNormalizeIntersectionThreshold(threshold[i]));
+      }
       thresholds = values.join(',');
     } else {
       throw new TypeError('IntersectionObserver threshold must be a number or array-like value');
     }
   }
 
-  let rootMargin = options.rootMargin == null ? null : String(options.rootMargin);
+  let rootMargin = options.rootMargin == null ? null
+    : __auiNormalizeIntersectionMargin(options.rootMargin, 'rootMargin');
+  let scrollMargin = options.scrollMargin == null ? null
+    : __auiNormalizeIntersectionMargin(options.scrollMargin, 'scrollMargin');
+  let delay = options.delay == null ? 0 : Number(options.delay);
+  if (!isFinite(delay) || delay < 0) throw new RangeError('IntersectionObserver delay must be a non-negative finite number');
+  delay = Math.floor(delay);
+  let trackVisibility = !!options.trackVisibility;
+  let observer = null;
   let nativeObserver = window.createIntersectionObserver(function(entries) {
-    callback(__auiDecorateIntersectionEntries(entries), observer);
-  }, root, rootMargin, thresholds);
-  let observer = {
-    observe: function(target) {
-      if (!target || typeof target.getNodeType !== 'function' || target.getNodeType() !== 1) {
-        throw new TypeError('IntersectionObserver target must be an Element');
-      }
-      nativeObserver.observe(__auiDecorateElement(target));
-    },
-    unobserve: function(target) {
-      if (!target || typeof target.getNodeType !== 'function' || target.getNodeType() !== 1) {
-        throw new TypeError('IntersectionObserver target must be an Element');
-      }
-      nativeObserver.unobserve(__auiDecorateElement(target));
-    },
-    disconnect: function() { nativeObserver.disconnect(); },
-    takeRecords: function() { return __auiDecorateIntersectionEntries(nativeObserver.takeRecords()); }
-  };
-  __auiInstallValueBridge(observer, 'root', () => __auiDecorateElement(nativeObserver.getRoot()));
+    if (!observer) return;
+    callback.call(observer, __auiDecorateIntersectionEntries(entries), observer);
+  }, root, rootMargin, scrollMargin, thresholds, delay, trackVisibility);
+  observer = Object.create(IntersectionObserver.prototype);
+  try {
+    Object.defineProperty(observer, '__auiNativeObserver', { value: nativeObserver, configurable: false });
+  } catch (e) {
+    observer.__auiNativeObserver = nativeObserver;
+  }
+  __auiInstallValueBridge(observer, 'root', () => {
+    let value = nativeObserver.getRoot();
+    return value === document ? document : __auiDecorateElement(value);
+  });
   __auiInstallValueBridge(observer, 'rootMargin', () => nativeObserver.getRootMargin());
+  __auiInstallValueBridge(observer, 'scrollMargin', () => nativeObserver.getScrollMargin());
   __auiInstallValueBridge(observer, 'thresholds', () => __auiDecorateIntersectionThresholds(nativeObserver.getThresholds()));
+  __auiInstallValueBridge(observer, 'delay', () => Number(nativeObserver.getDelay()));
+  __auiInstallValueBridge(observer, 'trackVisibility', () => !!nativeObserver.getTrackVisibility());
   return observer;
 }
 

--- a/common/src/test/java/com/sighs/apricityui/init/IntersectionObserverEngineTest.java
+++ b/common/src/test/java/com/sighs/apricityui/init/IntersectionObserverEngineTest.java
@@ -1,0 +1,178 @@
+package com.sighs.apricityui.init;
+
+import com.sighs.apricityui.init.Window.IntersectionEntryData;
+import com.sighs.apricityui.init.Window.IntersectionObserverEngine;
+import com.sighs.apricityui.init.Window.IntersectionOptions;
+import com.sighs.apricityui.init.Window.IntersectionRect;
+import com.sighs.apricityui.init.Window.IntersectionSnapshot;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IntersectionObserverEngineTest {
+    private static final IntersectionRect ROOT = new IntersectionRect(0, 0, 100, 100);
+
+    @Test
+    void intersectionsPreserveBoundaryContactsAndDistinguishSeparatedRects() {
+        IntersectionRect.Intersection contact = IntersectionRect.intersect(
+                new IntersectionRect(0, 0, 100, 100),
+                new IntersectionRect(100, 20, 20, 30)
+        );
+
+        assertTrue(contact.intersects());
+        assertEquals(new IntersectionRect(100, 20, 0, 30), contact.rect());
+
+        IntersectionRect.Intersection separated = IntersectionRect.intersect(
+                new IntersectionRect(0, 0, 10, 10),
+                new IntersectionRect(11, 0, 10, 10)
+        );
+
+        assertFalse(separated.intersects());
+        assertEquals(IntersectionRect.ZERO, separated.rect());
+    }
+
+    @Test
+    void normalizesRootMarginsAndThresholdsUsingRootWidthForAllPercentages() {
+        IntersectionOptions options = new IntersectionOptions(
+                "10% 20px 30% 40px",
+                List.of(0.75, 0.0, 0.75, 0.25)
+        );
+
+        assertEquals("10% 20px 30% 40px", options.rootMargin());
+        assertEquals(List.of(0.0, 0.25, 0.75), options.thresholds());
+        assertEquals(new IntersectionRect(-40, -10, 160, 240),
+                options.expandRootBounds(new IntersectionRect(0, 0, 100, 200)));
+        assertEquals("12px 5% 12px 5%", new IntersectionOptions("12px 5%", List.of()).rootMargin());
+        assertEquals(List.of(0.0), new IntersectionOptions("0px", List.of()).thresholds());
+    }
+
+    @Test
+    void rejectsInvalidRootMarginsAndThresholds() {
+        assertThrows(IllegalArgumentException.class, () -> new IntersectionOptions("10em", List.of()));
+        assertThrows(IllegalArgumentException.class, () -> new IntersectionOptions("1px 2px 3px 4px 5px", List.of()));
+        assertThrows(IllegalArgumentException.class, () -> new IntersectionOptions("0px", List.of(-0.1)));
+        assertThrows(IllegalArgumentException.class, () -> new IntersectionOptions("0px", List.of(Double.NaN)));
+        assertThrows(IllegalArgumentException.class, () -> new IntersectionOptions("0px", List.of(1.1)));
+    }
+
+    @Test
+    void queuesInitialEntryOnlyOnceForStableGeometryAndObserveIsIdempotent() {
+        Object target = new Object();
+        IntersectionObserverEngine<Object> engine = new IntersectionObserverEngine<>(
+                new IntersectionOptions("0px", List.of(0.0, 0.5, 1.0))
+        );
+
+        engine.observe(target);
+        engine.observe(target);
+        engine.evaluate(observed -> snapshot(observed, 10, new IntersectionRect(0, 0, 50, 50)));
+
+        List<IntersectionEntryData<Object>> initialEntries = engine.takeRecords();
+        assertEquals(1, initialEntries.size());
+        assertTrue(initialEntries.get(0).isIntersecting());
+        assertEquals(1.0, initialEntries.get(0).intersectionRatio(), 0.00001);
+
+        engine.evaluate(observed -> snapshot(observed, 20, new IntersectionRect(0, 0, 50, 50)));
+        assertTrue(engine.takeRecords().isEmpty());
+    }
+
+    @Test
+    void queuesOneEntryForIntersectionChangesAndThresholdCrossings() {
+        Object target = new Object();
+        IntersectionObserverEngine<Object> engine = new IntersectionObserverEngine<>(
+                new IntersectionOptions("0px", List.of(0.0, 0.25, 0.5, 0.75))
+        );
+        engine.observe(target);
+
+        engine.evaluate(observed -> snapshot(observed, 1, new IntersectionRect(-101, 0, 100, 100)));
+        assertEquals(1, engine.takeRecords().size());
+
+        engine.evaluate(observed -> snapshot(observed, 2, new IntersectionRect(-70, 0, 100, 100)));
+        assertSingleRatio(engine.takeRecords(), 0.3);
+
+        engine.evaluate(observed -> snapshot(observed, 3, new IntersectionRect(-40, 0, 100, 100)));
+        assertSingleRatio(engine.takeRecords(), 0.6);
+
+        engine.evaluate(observed -> snapshot(observed, 4, new IntersectionRect(-35, 0, 100, 100)));
+        assertTrue(engine.takeRecords().isEmpty());
+
+        engine.evaluate(observed -> snapshot(observed, 5, new IntersectionRect(-150, 0, 100, 100)));
+        List<IntersectionEntryData<Object>> exited = engine.takeRecords();
+        assertEquals(1, exited.size());
+        assertFalse(exited.get(0).isIntersecting());
+        assertEquals(0.0, exited.get(0).intersectionRatio(), 0.00001);
+    }
+
+    @Test
+    void appliesAncestorClipsAndPreservesBoundaryAndZeroAreaSemantics() {
+        Object target = new Object();
+        IntersectionObserverEngine<Object> engine = new IntersectionObserverEngine<>(
+                new IntersectionOptions("0px", List.of())
+        );
+        engine.observe(target);
+
+        engine.evaluate(observed -> new IntersectionSnapshot<>(
+                observed,
+                1,
+                ROOT,
+                new IntersectionRect(0, 0, 100, 100),
+                List.of(new IntersectionRect(0, 0, 10, 100))
+        ));
+        IntersectionEntryData<Object> clipped = engine.takeRecords().get(0);
+        assertTrue(clipped.isIntersecting());
+        assertEquals(new IntersectionRect(0, 0, 10, 100), clipped.intersectionRect());
+        assertEquals(0.1, clipped.intersectionRatio(), 0.00001);
+
+        engine.unobserve(target);
+        engine.observe(target);
+        engine.evaluate(observed -> snapshot(observed, 2, new IntersectionRect(100, 25, 10, 10)));
+        IntersectionEntryData<Object> touching = engine.takeRecords().get(0);
+        assertTrue(touching.isIntersecting());
+        assertEquals(new IntersectionRect(100, 25, 0, 10), touching.intersectionRect());
+        assertEquals(0.0, touching.intersectionRatio(), 0.00001);
+
+        engine.unobserve(target);
+        engine.observe(target);
+        engine.evaluate(observed -> snapshot(observed, 3, new IntersectionRect(20, 20, 0, 10)));
+        IntersectionEntryData<Object> zeroAreaTarget = engine.takeRecords().get(0);
+        assertTrue(zeroAreaTarget.isIntersecting());
+        assertEquals(1.0, zeroAreaTarget.intersectionRatio(), 0.00001);
+    }
+
+    @Test
+    void takeRecordsDrainsAtomicallyAndQueuedEntriesSurviveUnobserveAndDisconnect() {
+        Object first = new Object();
+        Object second = new Object();
+        IntersectionObserverEngine<Object> engine = new IntersectionObserverEngine<>(new IntersectionOptions("0px", List.of()));
+
+        engine.observe(first);
+        engine.evaluate(observed -> snapshot(observed, 1, new IntersectionRect(0, 0, 10, 10)));
+        engine.unobserve(first);
+        assertEquals(1, engine.takeRecords().size());
+        assertTrue(engine.takeRecords().isEmpty());
+
+        engine.observe(first);
+        engine.evaluate(observed -> snapshot(observed, 2, new IntersectionRect(0, 0, 10, 10)));
+        engine.disconnect();
+        assertEquals(1, engine.takeRecords().size());
+
+        engine.observe(second);
+        engine.evaluate(observed -> snapshot(observed, 3, new IntersectionRect(0, 0, 10, 10)));
+        List<IntersectionEntryData<Object>> records = engine.takeRecords();
+        assertEquals(1, records.size());
+        assertEquals(second, records.get(0).target());
+    }
+
+    private static IntersectionSnapshot<Object> snapshot(Object target, double time, IntersectionRect targetBounds) {
+        return new IntersectionSnapshot<>(target, time, ROOT, targetBounds, List.of());
+    }
+
+    private static void assertSingleRatio(List<IntersectionEntryData<Object>> entries, double expectedRatio) {
+        assertEquals(1, entries.size());
+        assertEquals(expectedRatio, entries.get(0).intersectionRatio(), 0.00001);
+    }
+}

--- a/common/src/test/java/com/sighs/apricityui/init/IntersectionObserverEngineTest.java
+++ b/common/src/test/java/com/sighs/apricityui/init/IntersectionObserverEngineTest.java
@@ -167,6 +167,102 @@ class IntersectionObserverEngineTest {
         assertEquals(second, records.get(0).target());
     }
 
+    @Test
+    void acceptsEmptyMarginsAndConvertsAbsoluteCssUnitsToPixels() {
+        IntersectionOptions options = new IntersectionOptions(
+                "1in 2.54cm 25.4mm 72pt",
+                "",
+                List.of(),
+                0,
+                false
+        );
+
+        assertEquals("96px 96px 96px 96px", options.rootMargin());
+        assertEquals("0px 0px 0px 0px", options.scrollMargin());
+        assertEquals(new IntersectionRect(-96, -96, 292, 292),
+                options.expandRootBounds(new IntersectionRect(0, 0, 100, 100)));
+        assertThrows(IllegalArgumentException.class,
+                () -> new IntersectionOptions("1", "0px", List.of(), 0, false));
+    }
+
+    @Test
+    void appliesScrollMarginSeparatelyAndEnforcesVisibilityDelayMinimum() {
+        IntersectionOptions options = new IntersectionOptions(
+                "0px",
+                "10% 20px",
+                List.of(),
+                25,
+                true
+        );
+
+        assertEquals("10% 20px 10% 20px", options.scrollMargin());
+        assertEquals(100, options.delay());
+        assertTrue(options.trackVisibility());
+        assertEquals(new IntersectionRect(-20, -10, 140, 120),
+                options.expandScrollBounds(new IntersectionRect(0, 0, 100, 100)));
+    }
+
+    @Test
+    void ancestorClipCanEmptyIntersectionRectWithoutErasingRootContact() {
+        Object target = new Object();
+        IntersectionObserverEngine<Object> engine = new IntersectionObserverEngine<>(
+                new IntersectionOptions("0px", List.of())
+        );
+        engine.observe(target);
+
+        engine.evaluate(ignored -> new IntersectionSnapshot<>(
+                target,
+                1,
+                ROOT,
+                new IntersectionRect(10, 10, 20, 20),
+                List.of(new IntersectionRect(80, 80, 10, 10))
+        ));
+
+        IntersectionEntryData<Object> entry = engine.takeRecords().get(0);
+        assertTrue(entry.isIntersecting());
+        assertEquals(IntersectionRect.ZERO, entry.intersectionRect());
+        assertEquals(0.0, entry.intersectionRatio(), 0.00001);
+    }
+
+    @Test
+    void delayKeepsLatestStateAndDeliversItAfterTheInterval() {
+        Object target = new Object();
+        IntersectionObserverEngine<Object> engine = new IntersectionObserverEngine<>(
+                new IntersectionOptions("0px", "0px", List.of(), 10, false)
+        );
+        engine.observe(target);
+
+        engine.evaluate(ignored -> snapshot(target, 0, new IntersectionRect(0, 0, 10, 10)));
+        assertEquals(1, engine.takeRecords().size());
+
+        engine.evaluate(ignored -> snapshot(target, 5, new IntersectionRect(-20, 0, 10, 10)));
+        assertTrue(engine.takeRecords().isEmpty());
+        engine.evaluate(ignored -> snapshot(target, 10, new IntersectionRect(-20, 0, 10, 10)));
+        List<IntersectionEntryData<Object>> exit = engine.takeRecords();
+        assertEquals(1, exit.size());
+        assertFalse(exit.get(0).isIntersecting());
+    }
+
+    @Test
+    void visibilityChangesProduceEntriesWhenTrackingIsEnabled() {
+        Object target = new Object();
+        IntersectionObserverEngine<Object> engine = new IntersectionObserverEngine<>(
+                new IntersectionOptions("0px", "0px", List.of(), 0, true)
+        );
+        engine.observe(target);
+
+        engine.evaluate(ignored -> new IntersectionSnapshot<>(
+                target, 0, ROOT, new IntersectionRect(0, 0, 10, 10), List.of(), true, false));
+        IntersectionEntryData<Object> hidden = engine.takeRecords().get(0);
+        assertTrue(hidden.isIntersecting());
+        assertFalse(hidden.isVisible());
+
+        engine.evaluate(ignored -> new IntersectionSnapshot<>(
+                target, 100, ROOT, new IntersectionRect(0, 0, 10, 10), List.of(), true, true));
+        IntersectionEntryData<Object> visible = engine.takeRecords().get(0);
+        assertTrue(visible.isVisible());
+    }
+
     private static IntersectionSnapshot<Object> snapshot(Object target, double time, IntersectionRect targetBounds) {
         return new IntersectionSnapshot<>(target, time, ROOT, targetBounds, List.of());
     }

--- a/common/src/test/java/com/sighs/apricityui/webapi/ForegroundPaintOrderTest.java
+++ b/common/src/test/java/com/sighs/apricityui/webapi/ForegroundPaintOrderTest.java
@@ -1,0 +1,110 @@
+package com.sighs.apricityui.webapi;
+
+import com.sighs.apricityui.init.Document;
+import com.sighs.apricityui.init.Element;
+import com.sighs.apricityui.render.Base;
+import com.sighs.apricityui.render.Drawer;
+import com.sighs.apricityui.render.ForegroundRenderNodeProvider;
+import com.sighs.apricityui.render.RenderNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ForegroundPaintOrderTest {
+    @Test
+    void foregroundPaintsAfterChildrenAndBeforeOverflowPop() {
+        Document document = TestDocumentFactory.createDocument();
+        ForegroundElement parent = new ForegroundElement(document);
+        parent.setAttribute("style", "overflow:hidden;width:40px;height:20px;");
+        Element child = new Element(document, "span");
+        child.setAttribute("style", "display:block;width:80px;height:20px;");
+        parent.appendChild(child);
+        document.body.appendChild(parent);
+
+        List<RenderNode> nodes = Drawer.createPaintList(document.body);
+        int childBody = indexOf(nodes, node -> phase(node, child, Base.RenderPhase.BODY));
+        int foreground = indexOf(nodes, node -> node instanceof RenderNode.ElementForegroundNode foregroundNode
+                && foregroundNode.target() == parent);
+        int pop = indexOf(nodes, node -> node instanceof RenderNode.MaskPopNode mask && mask.target() == parent);
+
+        assertTrue(childBody < foreground, "foreground must paint after every child");
+        assertTrue(foreground < pop, "foreground must remain inside the overflow clip");
+    }
+
+    @Test
+    void leafForegroundPaintsAfterItsBorder() {
+        Document document = TestDocumentFactory.createDocument();
+        ForegroundElement leaf = new ForegroundElement(document);
+        leaf.setAttribute("style", "width:20px;height:20px;");
+        document.body.appendChild(leaf);
+
+        List<RenderNode> nodes = Drawer.createPaintList(document.body);
+        int border = indexOf(nodes, node -> phase(node, leaf, Base.RenderPhase.BORDER));
+        int foreground = indexOf(nodes, node -> node instanceof RenderNode.ElementForegroundNode foregroundNode
+                && foregroundNode.target() == leaf);
+
+        assertTrue(border < foreground, "a leaf foreground must paint above its border");
+    }
+
+    @Test
+    void foregroundDepthTracksTheActiveItemDecorationLayer() {
+        Base.pushGuiItemZ(12.0F, 34.0F);
+        try {
+            assertEquals(34.125F, Base.getGuiItemForegroundZ(), 0.0001F);
+        } finally {
+            Base.popGuiItemZ();
+        }
+    }
+
+    @Test
+    void screenForegroundFitsBetweenItemDecorationsAndFloatingItems() {
+        Base.pushGuiItemZ(150.0F, 200.0F);
+        try {
+            float foreground = Base.getGuiItemForegroundZ();
+            assertTrue(foreground > Base.getGuiItemDecorationZ());
+            assertTrue(foreground < 200.25F, "foreground must remain below the floating item model layer");
+        } finally {
+            Base.popGuiItemZ();
+        }
+    }
+
+    @Test
+    void foregroundUsesItsOwnPaintIntervalInWorldDepthMode() {
+        Base.pushDepthMode(true);
+        Base.pushGuiItemZ(0.25F, 0.5F);
+        try {
+            assertEquals(0.0F, Base.getGuiItemForegroundZ(), 0.0001F);
+        } finally {
+            Base.popGuiItemZ();
+            Base.popDepthMode();
+        }
+    }
+
+    private static boolean phase(RenderNode node, Element target, Base.RenderPhase phase) {
+        return node instanceof RenderNode.ElementPhaseNode elementPhase
+                && elementPhase.target() == target
+                && elementPhase.phase() == phase;
+    }
+
+    private static int indexOf(List<RenderNode> nodes, Predicate<RenderNode> predicate) {
+        for (int index = 0; index < nodes.size(); index++) {
+            if (predicate.test(nodes.get(index))) return index;
+        }
+        throw new AssertionError("expected render node was not found");
+    }
+
+    private static final class ForegroundElement extends Element implements ForegroundRenderNodeProvider {
+        private ForegroundElement(Document document) {
+            super(document, "div");
+        }
+
+        @Override
+        public List<RenderNode> createForegroundRenderNodes() {
+            return List.of(new RenderNode.ElementForegroundNode(this, null));
+        }
+    }
+}

--- a/common/src/test/java/com/sighs/apricityui/webapi/GlobalJsBootstrapTest.java
+++ b/common/src/test/java/com/sighs/apricityui/webapi/GlobalJsBootstrapTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -113,9 +114,97 @@ class GlobalJsBootstrapTest {
         assertTrue(script.contains("function __auiDecorateIntersectionEntries(list)"));
         assertTrue(script.contains("function IntersectionObserver(callback, options)"));
         assertTrue(script.contains("window.createIntersectionObserver(function(entries)"));
-        assertTrue(script.contains("IntersectionObserver root must be an Element or null"));
-        assertTrue(script.contains("takeRecords: function() { return __auiDecorateIntersectionEntries(nativeObserver.takeRecords()); }"));
+        assertTrue(script.contains("IntersectionObserver root must be an Element, Document, or null"));
+        assertTrue(script.contains("takeRecords: function()"));
+        assertTrue(script.contains("__auiDecorateIntersectionEntries(this.__auiNativeObserver.takeRecords())"));
+        assertTrue(script.contains("isVisible: !!entry.isVisible"));
+        assertTrue(script.contains("scrollMargin = options.scrollMargin"));
+        assertTrue(script.contains("trackVisibility = !!options.trackVisibility"));
+        assertTrue(script.contains("__auiInstallValueBridge(observer, 'scrollMargin'"));
+        assertTrue(script.contains("__auiInstallValueBridge(observer, 'delay'"));
+        assertTrue(script.contains("__auiInstallValueBridge(observer, 'trackVisibility'"));
+        assertTrue(script.contains("callback.call(observer"));
         assertTrue(script.contains("__auiInstallValueBridge(observer, 'thresholds'"));
+    }
+
+    @Test
+    void intersectionObserverBootstrapUsesStandardizedOptionsAndPrototypeMethods() throws Exception {
+        String script = globalFunction("__auiDefineProperty")
+                + globalFunction("__auiInstallValueBridge")
+                + globalFunction("__auiDecorateIntersectionEntries")
+                + globalFunction("__auiDecorateIntersectionThresholds")
+                + "function __auiDecorateElement(el) { return el; }\n"
+                + "var document = {};\n"
+                + "var lastNativeCallback = null;\n"
+                + "var lastNativeArgs = null;\n"
+                + "var window = { createIntersectionObserver: function(cb, root, rm, sm, th, delay, tv) {"
+                + " lastNativeCallback = cb; lastNativeArgs = [root, rm, sm, th, delay, tv];"
+                + " return { getRoot: function() { return root; },"
+                + " getRootMargin: function() { return '96px 96px 96px 96px'; },"
+                + " getScrollMargin: function() { return '2px 2px 2px 2px'; },"
+                + " getThresholds: function() { return [0.5]; },"
+                + " getDelay: function() { return tv && delay < 100 ? 100 : delay; },"
+                + " getTrackVisibility: function() { return !!tv; },"
+                + " observe: function() {}, unobserve: function() {}, disconnect: function() {},"
+                + " takeRecords: function() { return []; } }; } };\n"
+                + globalSection("function __auiNormalizeIntersectionMargin", "function MutationObserver")
+                + "var rootElement = { getNodeType: function() { return 1; } };\n"
+                + "var callbackThis = null; var callbackObserver = null; var callbackEntry = null;\n"
+                + "var observer = new IntersectionObserver(function(entries, ob) {"
+                + " callbackThis = this; callbackObserver = ob; callbackEntry = entries[0];"
+                + "}, { root: rootElement, rootMargin: '1in', scrollMargin: '2px', threshold: [0.5], delay: 25, trackVisibility: true });\n"
+                + "lastNativeCallback([{ target: rootElement, time: 7, rootBounds: null, boundingClientRect: {}, intersectionRect: {}, isIntersecting: true, isVisible: true, intersectionRatio: 1 }]);\n"
+                + "var badMargin = false; try { new IntersectionObserver(function() {}, { rootMargin: 'bad' }); } catch (e) { badMargin = e instanceof SyntaxError; }\n"
+                + "[observer instanceof IntersectionObserver, observer.observe === IntersectionObserver.prototype.observe,"
+                + " lastNativeArgs[1], lastNativeArgs[2], observer.rootMargin, observer.scrollMargin, observer.delay,"
+                + " observer.trackVisibility, callbackThis === observer, callbackObserver === observer, callbackEntry.isVisible, badMargin].join('|');";
+
+        dev.latvian.mods.rhino.Context context = RhinoTestSupport.enterContext();
+        dev.latvian.mods.rhino.Scriptable scope = context.initStandardObjects();
+        Object result = context.evaluateString(scope, script, "intersection-observer-bootstrap", 1, null);
+
+        assertEquals("true|true|1in|2px|96px 96px 96px 96px|2px 2px 2px 2px|100|true|true|true|true|true", result);
+    }
+
+    private static String globalFunction(String name) {
+        String script = readGlobalJs();
+        String marker = "function " + name + "(";
+        int start = script.indexOf(marker);
+        if (start < 0) throw new AssertionError("Missing global function " + name);
+        int brace = script.indexOf('{', start);
+        int depth = 0;
+        char quote = 0;
+        boolean escaped = false;
+        for (int index = brace; index < script.length(); index++) {
+            char current = script.charAt(index);
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (current == '\\' && quote != 0) {
+                escaped = true;
+                continue;
+            }
+            if (quote != 0) {
+                if (current == quote) quote = 0;
+                continue;
+            }
+            if (current == 39 || current == '"' || current == '`') {
+                quote = current;
+                continue;
+            }
+            if (current == '{') depth++;
+            else if (current == '}' && --depth == 0) return script.substring(start, index + 1) + "\n";
+        }
+        throw new AssertionError("Unterminated global function " + name);
+    }
+
+    private static String globalSection(String startMarker, String endMarker) {
+        String script = readGlobalJs();
+        int start = script.indexOf(startMarker);
+        int end = script.indexOf(endMarker, start < 0 ? 0 : start);
+        if (start < 0 || end < 0) throw new AssertionError("Missing global section markers");
+        return script.substring(start, end);
     }
 
     private static String readGlobalJs() {

--- a/common/src/test/java/com/sighs/apricityui/webapi/GlobalJsBootstrapTest.java
+++ b/common/src/test/java/com/sighs/apricityui/webapi/GlobalJsBootstrapTest.java
@@ -105,6 +105,19 @@ class GlobalJsBootstrapTest {
         assertTrue(script.contains("__auiInstallValueBridge(el, 'style', () => __auiDecorateStyle(el)"));
     }
 
+    @Test
+    void globalJsIncludesIntersectionObserverBootstrap() {
+        String script = readGlobalJs();
+
+        assertNotNull(script);
+        assertTrue(script.contains("function __auiDecorateIntersectionEntries(list)"));
+        assertTrue(script.contains("function IntersectionObserver(callback, options)"));
+        assertTrue(script.contains("window.createIntersectionObserver(function(entries)"));
+        assertTrue(script.contains("IntersectionObserver root must be an Element or null"));
+        assertTrue(script.contains("takeRecords: function() { return __auiDecorateIntersectionEntries(nativeObserver.takeRecords()); }"));
+        assertTrue(script.contains("__auiInstallValueBridge(observer, 'thresholds'"));
+    }
+
     private static String readGlobalJs() {
         try (InputStream stream = GlobalJsBootstrapTest.class.getClassLoader()
                 .getResourceAsStream("assets/apricityui/apricity/global.js")) {

--- a/common/src/test/java/com/sighs/apricityui/webapi/LoaderIntegrationTest.java
+++ b/common/src/test/java/com/sighs/apricityui/webapi/LoaderIntegrationTest.java
@@ -20,6 +20,7 @@ class LoaderIntegrationTest {
         assertNotNull(globalJs);
         assertTrue(globalJs.contains("ApricityUI.getDocumentByUUID(\"__AUI_DOCUMENT_UUID__\")"));
         assertTrue(globalJs.contains("function MutationObserver(callback)"));
+        assertTrue(globalJs.contains("function IntersectionObserver(callback, options)"));
 
         try (InputStream stream = Loader.getResourceStream("global.js")) {
             assertNotNull(stream);

--- a/docs/ai-skill.md
+++ b/docs/ai-skill.md
@@ -88,7 +88,7 @@ function init() {
 document.addEventListener("DOMContentLoaded", init);
 ```
 
-**JS 环境的几个差异**：键盘修饰键是 `controlKey` 不是 `ctrlKey`；事件坐标已经是页面逻辑坐标，**不要乘**任何缩放系数；`fetch(url)` 只支持单参数 GET，`response.json()` 在 then 里同步调用；没有 WebGL/XHR/WebSocket/完整 Promise。DOM 查询修改、事件捕获冒泡、localStorage、Canvas 2D、定时器、ResizeObserver/MutationObserver 这些都有。
+**JS 环境的几个差异**：键盘修饰键是 `controlKey` 不是 `ctrlKey`；事件坐标已经是页面逻辑坐标，**不要乘**任何缩放系数；`fetch(url)` 只支持单参数 GET，`response.json()` 在 then 里同步调用；没有 WebGL/XHR/WebSocket/完整 Promise。DOM 查询修改、事件捕获冒泡、localStorage、Canvas 2D、定时器、ResizeObserver/IntersectionObserver/MutationObserver 这些都有。IntersectionObserver 是按文档帧提交的 V1 核心子集：可用 root/rootMargin/threshold，不能用 trackVisibility、delay、scrollMargin、跨 Document 或依赖变换/clip-path 的精确相交。
 
 **扩展元素**（标准标签之外的 MC 向标签，都是普通 DOM 元素，都必须给 CSS 宽高）：
 

--- a/docs/en/ai-skill.md
+++ b/docs/en/ai-skill.md
@@ -88,7 +88,7 @@ function init() {
 document.addEventListener("DOMContentLoaded", init);
 ```
 
-**A few differences in the JS environment**: the keyboard modifier is `controlKey`, not `ctrlKey`; event coordinates are already page logical coordinates — **do not multiply** them by any scale factor; `fetch(url)` only supports single-argument GET, and `response.json()` is called synchronously inside `then`; there is no WebGL/XHR/WebSocket/full Promise. DOM query and mutation, event capture and bubbling, localStorage, Canvas 2D, timers, ResizeObserver/MutationObserver are all available.
+**A few differences in the JS environment**: the keyboard modifier is `controlKey`, not `ctrlKey`; event coordinates are already page logical coordinates — **do not multiply** them by any scale factor; `fetch(url)` only supports single-argument GET, and `response.json()` is called synchronously inside `then`; there is no WebGL/XHR/WebSocket/full Promise. DOM query and mutation, event capture and bubbling, localStorage, Canvas 2D, timers, ResizeObserver/IntersectionObserver/MutationObserver are all available. IntersectionObserver is the V1 core subset dispatched after document-frame commits: use root/rootMargin/threshold, but not trackVisibility, delay, scrollMargin, cross-Document observation, or precise transform/clip-path intersections.
 
 **Extended elements** (MC-oriented tags beyond the standard ones; all are ordinary DOM elements, and all must be given CSS width and height):
 

--- a/docs/en/guide/web-api.md
+++ b/docs/en/guide/web-api.md
@@ -43,10 +43,10 @@ Each Document has its own `document`, and they share one window compatibility ob
 | setTimeout / setInterval / requestAnimationFrame | Lightweight | driven by the client scheduler |
 | Event / CustomEvent / MouseEvent / WheelEvent / PointerEvent | Available | constructors read a limited set of fields |
 | URLSearchParams / FormData | Lightweight | smaller method sets than the standard |
-| ResizeObserver / MutationObserver | Lightweight | dispatched per document frame, not at microtask timing |
+| ResizeObserver / IntersectionObserver / MutationObserver | Lightweight | dispatched per document frame, not at microtask timing |
 | DOMMatrix / Path2D / OffscreenCanvas / createImageBitmap | Lightweight | see the Canvas section |
 
-**Not provided**: KeyboardEvent constructor, navigator.clipboard, Selection/Range, history, matchMedia, XMLHttpRequest, WebSocket, IntersectionObserver, WebGL, Service Worker, full Promise, AbortController, Shadow DOM, iframe/postMessage. Text selection and copy is AUI's own implementation — don't write code against Selection/Range.
+**Not provided**: KeyboardEvent constructor, navigator.clipboard, Selection/Range, history, matchMedia, XMLHttpRequest, WebSocket, WebGL, Service Worker, full Promise, AbortController, Shadow DOM, iframe/postMessage. Text selection and copy is AUI's own implementation — don't write code against Selection/Range.
 
 ## Window
 
@@ -279,6 +279,27 @@ ro.observe(el);  ro.unobserve(el);  ro.disconnect();
 An entry has `target/contentRect/borderBoxSize/contentBoxSize`; contentRect additionally has `borderBoxWidth/borderBoxHeight` beyond the regular rect fields. Without an actual size change, the callback is not fired again.
 
 ```javascript
+var io = new IntersectionObserver(function (entries, observer) {
+    for (var i = 0; i < entries.length; i++) {
+        var entry = entries[i];
+        if (entry.isIntersecting) console.log(entry.target, entry.intersectionRatio);
+    }
+}, {
+    root: null,                         // null = the Document logical viewport
+    rootMargin: "20px 0px",
+    threshold: [0, 0.5, 1]
+});
+io.observe(el);
+io.unobserve(el);
+io.takeRecords();
+io.disconnect();
+```
+
+An `IntersectionObserver` entry exposes `target/time/rootBounds/boundingClientRect/intersectionRect/isIntersecting/intersectionRatio`. The observer exposes read-only `root/rootMargin/thresholds`; rootMargin is normalized to four values and thresholds are sorted and deduplicated. `root` must be an Element from the same Document or null. An explicit root uses its committed padding overflow clip (including scrollbar gutters) when it clips overflow, otherwise its border box. A target also uses its committed border box plus ancestor overflow clips from the actual paint list. rootMargin accepts one to four `px` or `%` values; every percentage resolves against root width. Invalid rootMargin or threshold values throw.
+
+This is the V1 core subset: `trackVisibility`, `delay`, `scrollMargin`, cross-Document observation, and precise transform or `clip-path` intersections are not supported. `visibility:hidden` is not automatically non-intersecting; `display:none`, disconnected nodes, and inactive Documents cannot produce an intersecting result.
+
+```javascript
 var mo = new MutationObserver(function (records) { ... });
 mo.observe(document.documentElement, {
     childList: true, attributes: true, characterData: true, subtree: true,
@@ -290,7 +311,7 @@ mo.takeRecords();  mo.disconnect();
 
 A record exposes `type/target/addedNodes/removedNodes/previousSibling/nextSibling/attributeName/oldValue`.
 
-Both dispatch in batches per document frame, not at browser microtask timing. After a Document refresh, observers are cleaned up — you must re-query the nodes and observe them again.
+All three dispatch in batches per document frame, not at browser microtask timing. IntersectionObserver collects entries after every Document has committed layout and its paint list for the frame, then invokes callbacks; style changes, scrolling, unobserve, or disconnect inside a callback affect the next frame. After a Document refresh, observers are cleaned up — you must re-query the nodes and observe them again.
 
 ## Canvas and Images
 

--- a/docs/guide/web-api.md
+++ b/docs/guide/web-api.md
@@ -43,10 +43,10 @@ CSS 属性和布局见 [HTML/CSS 覆盖面](html-css-coverage)，页面级的 vi
 | setTimeout / setInterval / requestAnimationFrame | 轻量 | 客户端调度器驱动 |
 | Event / CustomEvent / MouseEvent / WheelEvent / PointerEvent | 可用 | 构造器读取的字段有限 |
 | URLSearchParams / FormData | 轻量 | 方法集比标准少 |
-| ResizeObserver / MutationObserver | 轻量 | 按文档帧派发，不是微任务时机 |
+| ResizeObserver / IntersectionObserver / MutationObserver | 轻量 | 按文档帧派发，不是微任务时机 |
 | DOMMatrix / Path2D / OffscreenCanvas / createImageBitmap | 轻量 | 见 Canvas 节 |
 
-**没有提供**：KeyboardEvent 构造器、navigator.clipboard、Selection/Range、history、matchMedia、XMLHttpRequest、WebSocket、IntersectionObserver、WebGL、Service Worker、完整 Promise、AbortController、Shadow DOM、iframe/postMessage。文字选择复制是 AUI 自己的实现，别按 Selection/Range 写。
+**没有提供**：KeyboardEvent 构造器、navigator.clipboard、Selection/Range、history、matchMedia、XMLHttpRequest、WebSocket、WebGL、Service Worker、完整 Promise、AbortController、Shadow DOM、iframe/postMessage。文字选择复制是 AUI 自己的实现，别按 Selection/Range 写。
 
 ## Window
 
@@ -279,6 +279,27 @@ ro.observe(el);  ro.unobserve(el);  ro.disconnect();
 entry 有 `target/contentRect/borderBoxSize/contentBoxSize`；contentRect 除了常规矩形字段还有 `borderBoxWidth/borderBoxHeight`。没有实际尺寸变化不会重复回调。
 
 ```javascript
+var io = new IntersectionObserver(function (entries, observer) {
+    for (var i = 0; i < entries.length; i++) {
+        var entry = entries[i];
+        if (entry.isIntersecting) console.log(entry.target, entry.intersectionRatio);
+    }
+}, {
+    root: null,                         // null = Document 逻辑 viewport
+    rootMargin: "20px 0px",
+    threshold: [0, 0.5, 1]
+});
+io.observe(el);
+io.unobserve(el);
+io.takeRecords();
+io.disconnect();
+```
+
+`IntersectionObserver` 的 entry 有 `target/time/rootBounds/boundingClientRect/intersectionRect/isIntersecting/intersectionRatio`。实例只读 `root/rootMargin/thresholds`，其中 rootMargin 会规范为四值，threshold 会排序去重。`root` 必须是同一 Document 的 Element 或 null；显式 root 在 overflow 裁剪时使用提交后的 padding clip（含滚动条 gutter），否则使用 border box。target 也基于提交后的 border box，并叠加实际 paint-list 中的祖先 overflow clip。rootMargin 只支持 1–4 个 `px` 或 `%` 值，所有百分比都按 root 宽度解析；非法 rootMargin 或 threshold 会抛错。
+
+这是 V1 核心子集：没有 `trackVisibility`、`delay`、`scrollMargin`、跨 Document 观察、变换或 `clip-path` 的精确相交。`visibility:hidden` 不会自动视为不可相交；`display:none`、断连或失活 Document 不会产生可相交结果。
+
+```javascript
 var mo = new MutationObserver(function (records) { ... });
 mo.observe(document.documentElement, {
     childList: true, attributes: true, characterData: true, subtree: true,
@@ -290,7 +311,7 @@ mo.takeRecords();  mo.disconnect();
 
 record 可读 `type/target/addedNodes/removedNodes/previousSibling/nextSibling/attributeName/oldValue`。
 
-两者都按文档帧批量派发，不是浏览器微任务时机。Document 刷新后观察器被清理，必须重新查询节点重新 observe。
+三者都按文档帧批量派发，不是浏览器微任务时机。IntersectionObserver 在所有 Document 完成该轮布局和 paint-list 提交后统一收集，再调用回调；回调内的样式、滚动、unobserve 或 disconnect 影响下一轮。Document 刷新后观察器被清理，必须重新查询节点重新 observe。
 
 ## Canvas 和图像
 

--- a/docs/guide/web-api.md
+++ b/docs/guide/web-api.md
@@ -287,7 +287,10 @@ var io = new IntersectionObserver(function (entries, observer) {
 }, {
     root: null,                         // null = Document 逻辑 viewport
     rootMargin: "20px 0px",
-    threshold: [0, 0.5, 1]
+    scrollMargin: "0px",               // 扩大路径上的滚动裁剪区域
+    threshold: [0, 0.5, 1],
+    trackVisibility: true,
+    delay: 100                          // trackVisibility=true 时最少 100ms
 });
 io.observe(el);
 io.unobserve(el);
@@ -295,9 +298,9 @@ io.takeRecords();
 io.disconnect();
 ```
 
-`IntersectionObserver` 的 entry 有 `target/time/rootBounds/boundingClientRect/intersectionRect/isIntersecting/intersectionRatio`。实例只读 `root/rootMargin/thresholds`，其中 rootMargin 会规范为四值，threshold 会排序去重。`root` 必须是同一 Document 的 Element 或 null；显式 root 在 overflow 裁剪时使用提交后的 padding clip（含滚动条 gutter），否则使用 border box。target 也基于提交后的 border box，并叠加实际 paint-list 中的祖先 overflow clip。rootMargin 只支持 1–4 个 `px` 或 `%` 值，所有百分比都按 root 宽度解析；非法 rootMargin 或 threshold 会抛错。
+`IntersectionObserver` 的 entry 有 `target/time/rootBounds/boundingClientRect/intersectionRect/isIntersecting/isVisible/intersectionRatio`。实例只读 `root/rootMargin/scrollMargin/thresholds/delay/trackVisibility`；rootMargin 和 scrollMargin 会规范为四值，threshold 会排序去重。`root` 可以是同一 Document 的 Element、Document 或 null；显式 root 的目标必须是它的后代。显式 root 在 overflow 裁剪时使用提交后的 padding clip（含滚动条 gutter），否则使用 border box；target 基于提交后的 border box，并沿目标到 root 的祖先链应用 overflow 裁剪。`rootMargin` 只扩大 root，`scrollMargin` 只扩大路径上的滚动裁剪，百分比均按未扩大的矩形宽度解析；支持 CSS 绝对长度和百分比，非法值会抛错。`trackVisibility` 开启后会填充 `isVisible`，且 `delay` 自动提升到至少 100ms。
 
-这是 V1 核心子集：没有 `trackVisibility`、`delay`、`scrollMargin`、跨 Document 观察、变换或 `clip-path` 的精确相交。`visibility:hidden` 不会自动视为不可相交；`display:none`、断连或失活 Document 不会产生可相交结果。
+观察器仍按文档帧批量派发；目标可以在插入 DOM 前注册，断连或 `display:none` 时会产生不相交状态，而不会被静默删除。当前实现仍不提供跨 Document/跨源观察，也不承诺滤镜、遮挡等复杂合成场景的像素级可见性。
 
 ```javascript
 var mo = new MutationObserver(function (records) { ... });


### PR DESCRIPTION
## Change Class

- [ ] `target-only`
- [ ] `common-internal`
- [x] `common-contract`
- [x] `cross-target-feature`
- [ ] `build-or-ci`
- [ ] `docs-only`

## Affected Targets

- [x] Forge 1.20.1
- [x] Fabric 1.20.1
- [x] Fabric 1.21.1
- [x] NeoForge 1.21.1
- [x] NeoForge 26.1
- [x] `common`

## Summary

新增浏览器风格的 `IntersectionObserver` 核心 API：支持 `root`、`rootMargin`、`threshold`、`observe`、`unobserve`、`disconnect` 和 `takeRecords`，并提供标准形状的 entry 字段。

实现位于共享 `common` 源码，因为观察器依赖统一的 Document 提交布局、paint-list overflow 裁剪、Window JS bridge 和帧调度；所有 loader 共享同一行为。

## Cross-Version Impact

- [ ] This PR does not change `common`.
- [ ] This PR changes `common` without changing its public contract.
- [x] This PR changes a `common` contract; all affected targets are updated and validated.
- [ ] A target is intentionally not updated; the reason and tracking issue are below.

## Release Notes

此功能应包含在 Forge 1.20.1、Fabric 1.20.1/1.21.1、NeoForge 1.21.1/26.1 的 jar 中。

限制：仅实现 IntersectionObserver V1 核心子集；暂不支持 `trackVisibility`、`delay`、`scrollMargin`、跨 Document 观察，以及 transform 或 `clip-path` 的精确相交计算。