### PR TITLE
fix(neo21.1+neo26.1): allow AUI on dedicated servers and make payload channels optional

### DIFF
--- a/targets/neoforge-1.21.1/src/main/java/com/sighs/apricityui/neoforge/AuiServicesBootstrap.java
+++ b/targets/neoforge-1.21.1/src/main/java/com/sighs/apricityui/neoforge/AuiServicesBootstrap.java
@@ -16,8 +16,9 @@ public final class AuiServicesBootstrap {
         AuiServices.setExpander(new ForgeDocumentExpander());
         AuiServices.setConfig(ConfigService.INSTANCE);
         AuiServices.setScript(ScriptService.INSTANCE);
-        AuiServices.setRender(RenderService.INSTANCE);
-        AuiServices.setItems(ItemRenderService.INSTANCE);
+        // Render/Items 引用客户端专属类（blaze3d/Minecraft），只能在客户端注册
+        // （见 ClientServicesBootstrap）；否则专用服务器加载本类时会
+        // NoClassDefFoundError 并导致整个服务器崩溃。
     }
 
     private AuiServicesBootstrap() {

--- a/targets/neoforge-1.21.1/src/main/java/com/sighs/apricityui/neoforge/ClientServicesBootstrap.java
+++ b/targets/neoforge-1.21.1/src/main/java/com/sighs/apricityui/neoforge/ClientServicesBootstrap.java
@@ -18,6 +18,7 @@ public final class ClientServicesBootstrap {
         AuiServices.setResources(ResourceService.INSTANCE);
         AuiServices.setKeys(KeyService.INSTANCE);
         AuiServices.setRender(RenderService.INSTANCE);
+        AuiServices.setItems(ItemRenderService.INSTANCE);
         DevToolsLogBridge.install(ApricityUI.LOGGER);
         modEventBus.addListener(ClientServicesBootstrap::onRegisterShaders);
     }

--- a/targets/neoforge-1.21.1/src/main/java/com/sighs/apricityui/network/neoforge/NetworkManagerImpl.java
+++ b/targets/neoforge-1.21.1/src/main/java/com/sighs/apricityui/network/neoforge/NetworkManagerImpl.java
@@ -41,7 +41,11 @@ public class NetworkManagerImpl implements INetworkManager {
 
     @SubscribeEvent
     public static void onRegisterPayloads(RegisterPayloadHandlersEvent event) {
-        final var registrar = event.registrar(ApricityUI.MODID).versioned(PROTOCOL_VERSION);
+        final var registrar = event.registrar(ApricityUI.MODID).versioned(PROTOCOL_VERSION)
+        // Neo: payload channels must be optional so that a client running ApricityUI can
+        // connect to servers that do not have ApricityUI installed (the server does not
+        // declare these channels, and a required registration would reject the handshake).
+        .optional();
         NetworkManagerImpl impl = new NetworkManagerImpl();
 
         for (Class<? extends INetworkPacket<?>> packetClass : NetworkAutoRegistration.findAllAnnotatedPackets()) {

--- a/targets/neoforge-26.1/src/main/java/com/sighs/apricityui/neoforge/AuiServicesBootstrap.java
+++ b/targets/neoforge-26.1/src/main/java/com/sighs/apricityui/neoforge/AuiServicesBootstrap.java
@@ -16,7 +16,9 @@ public final class AuiServicesBootstrap {
         AuiServices.setExpander(new ForgeDocumentExpander());
         AuiServices.setConfig(ConfigService.INSTANCE);
         AuiServices.setScript(ScriptService.INSTANCE);
-        AuiServices.setItems(ItemRenderService.INSTANCE);
+        // Items 引用客户端专属类（blaze3d/Minecraft），只能在客户端注册
+        // （见 ClientServicesBootstrap）；否则专用服务器加载本类时会
+        // NoClassDefFoundError 并导致整个服务器崩溃。
     }
 
     private AuiServicesBootstrap() {

--- a/targets/neoforge-26.1/src/main/java/com/sighs/apricityui/neoforge/ClientServicesBootstrap.java
+++ b/targets/neoforge-26.1/src/main/java/com/sighs/apricityui/neoforge/ClientServicesBootstrap.java
@@ -23,6 +23,7 @@ public final class ClientServicesBootstrap {
         AuiServices.setResources(ResourceService.INSTANCE);
         AuiServices.setKeys(KeyService.INSTANCE);
         AuiServices.setRender(RenderService.INSTANCE);
+        AuiServices.setItems(ItemRenderService.INSTANCE);
         DevToolsLogBridge.install(ApricityUI.LOGGER);
         ApricityUIRegistry.register();
 

--- a/targets/neoforge-26.1/src/main/java/com/sighs/apricityui/network/neoforge/NetworkManagerImpl.java
+++ b/targets/neoforge-26.1/src/main/java/com/sighs/apricityui/network/neoforge/NetworkManagerImpl.java
@@ -43,7 +43,11 @@ public class NetworkManagerImpl implements INetworkManager {
 
     @SubscribeEvent
     public static void onRegisterPayloads(RegisterPayloadHandlersEvent event) {
-        final var registrar = event.registrar(ApricityUI.MODID).versioned(PROTOCOL_VERSION);
+        final var registrar = event.registrar(ApricityUI.MODID).versioned(PROTOCOL_VERSION)
+        // Neo: payload channels must be optional so that a client running ApricityUI can
+        // connect to servers that do not have ApricityUI installed (the server does not
+        // declare these channels, and a required registration would reject the handshake).
+        .optional();
         NetworkManagerImpl impl = new NetworkManagerImpl();
 
         for (Class<? extends INetworkPacket<?>> packetClass : NetworkAutoRegistration.findAllAnnotatedPackets()) {


### PR DESCRIPTION
## Change Class

- [ ] `target-only`
- [ ] `common-internal`
- [ ] `common-contract`
- [x] `cross-target-feature`
- [ ] `build-or-ci`
- [ ] `docs-only`

## Affected Targets

- [ ] Forge 1.20.1
- [ ] Fabric 1.20.1
- [x] NeoForge 1.21.1
- [x] NeoForge 26.1
- [ ] `common`

## Summary

Two related interoperability fixes for the "dedicated server + client" deployment:

### 1. Payload channels are now optional

The client registers its payload channels without `.optional()`, i.e. required. Joining a server without ApricityUI fails the handshake:

```
Channel [apricityui:open_screen] failed to connect: ... This channel is missing on the server side, but required on the client!
Client disconnected with reason: Incompatible client!
```

Since ApricityUI could not run on dedicated servers at all (see #2), "server also installs AUI" was not a workaround. Marking the registrar optional is safe: a client with AUI never sends those payloads to a server that does not declare the channels.

### 2. ApricityUI can now load on dedicated servers

`AuiServicesBootstrap` unconditionally registered `RenderService` and `ItemRenderService` in its static initializer. Both reference client-only classes (`blaze3d` / `net.minecraft.client`), which are stripped from the dedicated-server jar, so mod construction crashed with `NoClassDefFoundError` and took the whole server down.

Both registrations moved into `ClientServicesBootstrap`, which only runs when `dist == CLIENT`. Dedicated servers now keep the server-safe services (network, config, script, expander) and register the payload channels, so a server-side ApricityUI installation is now a valid topology too.

## Validation

```text
JDK: 21 (Temurin/Graal, macOS arm64)
Command: built patched AUI jar, swapped it into a NeoForge 21.1.248 mod (buildshop) dev environment
Result:
  Topology A (no AUI on server): patched client joins a dedicated server started WITHOUT ApricityUI (-PserverOnly): "Dev joined the game", no channel/handshake errors. Unpatched 1.2.1 client on the same server is rejected (reproduced before the fix).
  Topology B (AUI on server): dedicated server started WITH ApricityUI loads cleanly (Done), registers apricityui:open_screen / close_container / generic_chunk, and a real client joins and plays normally. Before the fix this server crashed during mod construction.
  In both topologies the shop screen opens, sync (26 products / 10 categories) and purchases work.
Runtime verification: dedicated server (NeoForge 21.1.248) + real client, end-to-end
```

## Cross-Version Impact

- [x] This PR does not change `common`.
- [ ] This PR changes `common` without changing its public contract.
- [ ] This PR changes a `common` contract; all affected targets are updated and validated.
- [ ] A target is intentionally not updated; the reason and tracking issue are below.

## Release Notes

Both NeoForge targets (1.21.1 and 26.1) should include this change. Together these fixes make both supported topologies work: dedicated server without ApricityUI + client with ApricityUI, and dedicated server with ApricityUI installed.