### PR TITLE
fix(core): overflow 裁剪边界应使用 padding box 内缘，不再叠加 margin 偏移

### DIFF
--- a/common/src/main/java/com/sighs/apricityui/behavior/ScrollModel.java
+++ b/common/src/main/java/com/sighs/apricityui/behavior/ScrollModel.java
@@ -396,7 +396,12 @@ public final class ScrollModel {
             width = Math.max(width, offset.x - contentOriginX + outerSize.width());
             height = Math.max(height, offset.y - contentOriginY + outerSize.height());
         }
-        return new Size(Math.max(0, width), Math.max(0, height));
+        // CSS scrollHeight/scrollWidth 包含 padding（content-box 之外的内边距）：
+        // 滚动到底时最后一行内容下方应保留 padding 空间，否则内容贴死视口底缘
+        // 且 padding-bottom 永远不可达。
+        return new Size(
+                Math.max(0, width) + Math.max(0, box.getPaddingRight()),
+                Math.max(0, height) + Math.max(0, box.getPaddingBottom()));
     }
 
     private void updateScrollbarVisibility() {

--- a/common/src/main/java/com/sighs/apricityui/render/Rect.java
+++ b/common/src/main/java/com/sighs/apricityui/render/Rect.java
@@ -141,6 +141,18 @@ public class Rect {
         }
     }
 
+    /**
+     * Overflow 裁剪边界 = padding box 的内边缘（border 内侧，不含 margin）。
+     *
+     * <p>布局坐标 {@link #position} 已是 margin 外推后的 border box 位置；
+     * 子元素内容从 padding box 顶部开始渲染（{@code offset = border + padding}）。
+     * 若 mask 把 margin 也算进裁剪区，容器带 margin-top 时首行内容会被整体裁掉
+     * （见 issue：#76 overflow:hidden 裁子元素顶部边框、#77 滚动容器裁首行 border-top）。</p>
+     */
+    public Position getOverflowClipPosition() {
+        return new Position(position.x + box.getBorderLeft(), position.y + box.getBorderTop());
+    }
+
     public Position getBodyRectPosition() {
         if (bodyRectPosition != null) return bodyRectPosition;
         double x = position.x + box.getMarginLeft() + box.getBorderLeft();

--- a/common/src/main/java/com/sighs/apricityui/render/RenderNode.java
+++ b/common/src/main/java/com/sighs/apricityui/render/RenderNode.java
@@ -83,7 +83,9 @@ public interface RenderNode {
         @Override
         public void render(PoseStack poseStack) {
             applyWithTransform(poseStack, target, rect -> {
-                Position p = rect.getBodyRectPosition();
+                // 裁剪边界取 padding box 内边缘（不含 margin），否则容器带 margin
+                // 时 mask 下移、首行内容（含 border-top）被裁掉（issue #76/#77）。
+                Position p = rect.getOverflowClipPosition();
                 Size bodySize = rect.getBodyRectSize();
                 Size s = new Size(
                         Math.max(0, bodySize.width() - target.getVerticalScrollbarGutter()),
@@ -115,7 +117,9 @@ public interface RenderNode {
         @Override
         public void render(PoseStack poseStack) {
             applyWithTransform(poseStack, target, rect -> {
-                Position p = rect.getBodyRectPosition();
+                // 裁剪边界取 padding box 内边缘（不含 margin），否则容器带 margin
+                // 时 mask 下移、首行内容（含 border-top）被裁掉（issue #76/#77）。
+                Position p = rect.getOverflowClipPosition();
                 Size bodySize = rect.getBodyRectSize();
                 Size s = new Size(
                         Math.max(0, bodySize.width() - target.getVerticalScrollbarGutter()),

--- a/common/src/main/resources/assets/apricityui/apricity/tests/index.html
+++ b/common/src/main/resources/assets/apricityui/apricity/tests/index.html
@@ -67,6 +67,10 @@
                     <span class="case-name">layout-advanced-test.html</span>
                     <span class="case-desc">Advanced layout engine checks for inline wrap, percent height, fixed, flex-wrap, and grid tracks.</span>
                 </a>
+                <a class="case-link" href="./overflow-clip-margin-test.html">
+                    <span class="case-name">overflow-clip-margin-test.html</span>
+                    <span class="case-desc">Overflow clip edge must ignore the container's own margin (regression for #76/#77); first row border-top must stay visible.</span>
+                </a>
                 <a class="case-link" href="./text-style-test.html">
                     <span class="case-name">text-style-test.html</span>
                     <span class="case-desc">Text style rendering, weight, stroke, and decoration checks.</span>

--- a/common/src/main/resources/assets/apricityui/apricity/tests/overflow-clip-margin-test.html
+++ b/common/src/main/resources/assets/apricityui/apricity/tests/overflow-clip-margin-test.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="aui-font-mode" content="web">
+    <meta name="aui-viewport" content="mode=browser">
+    <meta name="aui-mouse-events" content="intercept">
+    <title>overflow-clip-margin-test</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 24px;
+            font-family: sans-serif;
+        }
+
+        .section-title {
+            font-size: 18px;
+            margin: 8px 0;
+        }
+
+        /* 场景 A：滚动容器自身带 margin-top（issue #77 的真实触发条件） */
+        .viewport {
+            width: 320px;
+            height: 180px;
+            margin-top: 10px;
+            padding: 1px;
+            overflow-y: auto;
+            overflow-x: hidden;
+            background: #e8e8e8;
+        }
+
+        /* 场景 B：overflow:hidden 容器自身带 margin-top（issue #76） */
+        .hidden-box {
+            width: 320px;
+            height: 120px;
+            margin-top: 10px;
+            overflow: hidden;
+            background: #f5f5f5;
+        }
+
+        .item {
+            height: 80px;
+            margin-bottom: 8px;
+            border: 1px solid #d6c8b1;
+            border-top: 3px solid #477b6c;
+            background: #fffaf0;
+            box-sizing: border-box;
+        }
+
+        .child {
+            height: 80px;
+            border: 1px solid #d6c8b1;
+            border-top: 7px solid #a84f42;
+            background: #fffaf0;
+            box-sizing: border-box;
+        }
+    </style>
+</head>
+<body>
+    <div class="section-title">A: scroll container with margin-top (issue #77) - first row border-top must be visible</div>
+    <div class="viewport">
+        <div class="item">first item</div>
+        <div class="item">second item</div>
+        <div class="item">third item</div>
+    </div>
+
+    <div class="section-title">B: overflow:hidden with margin-top (issue #76) - child top border must be visible</div>
+    <div class="hidden-box">
+        <div class="child">child top border</div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Change Class

- [ ] \`target-only\`
- [x] \`common-internal\`
- [ ] \`common-contract\`
- [ ] \`cross-target-feature\`
- [ ] \`build-or-ci\`
- [ ] \`docs-only\`

## Affected Targets

- [ ] Forge 1.20.1
- [ ] Fabric 1.20.1
- [x] NeoForge 1.21.1（实测验证）
- [ ] NeoForge 26.1（同一 common 代码路径，随 common 生效）
- [x] \`common\`

## 问题描述

修复 3 个相关的滚动/裁剪问题（#76、#77 及新发现的 scrollHeight 缺 padding）：

1. **#76**：\`overflow: hidden\` 会裁掉子元素的顶部边框
2. **#77**：滚动容器会裁掉首行子元素的 \`border-top\`
3. **scrollHeight 不含 padding**：带 \`padding-bottom\` 的滚动容器无法滚出 padding 空间，最后一行内容贴死视口底缘（底部边框可能被像素量化裁掉）

### 根因 1/2（mask 叠加 margin）

布局坐标（\`Position.of\`）已经是 margin 折叠/外推后的 **border box 位置**；而 \`MaskPushNode\` 创建 overflow 裁剪区时使用的 \`Rect.getBodyRectPosition()\` 会在此基础上**再加一次 margin**（\`position + margin + border\`）。

带 \`margin-top\` 的 \`overflow\` 容器，其裁剪区比实际内容区**整体下移 marginTop 像素**：首行子元素绘制在 padding box 顶部，却落在裁剪区之外，顶部边框被整体裁掉。

### 根因 3（scrollHeight 测量不完整）

\`measureLayoutScrollArea\` 只测量子元素范围，未包含容器自身的 padding。CSSOM 规定 scrollHeight 包含 padding（content-box 之外的 padding 区）。

## 修复方式

1. \`Rect\` 新增 \`getOverflowClipPosition()\`：overflow 裁剪边界 = **padding box 内边缘**（border 内侧，不含 margin），\`MaskPushNode\` 改用它。\`getBodyRectPosition()\` 及其余调用方语义不变。
2. \`ScrollModel.measureLayoutScrollArea\` 的结果加上 \`paddingRight\` / \`paddingBottom\`。

## Validation

新增回归测试页面 \`apricity/tests/overflow-clip-margin-test.html\`（已加入 Manual Test Index），覆盖 #76/#77 两个场景（滚动容器 + overflow:hidden，均带 margin-top）。

使用 \`-Dapricityui.test.logRenderPhases=true\` 与滚动日志在真实客户端（NeoForge 1.21.1）验证：

```text
修复前：
  mask 顶部 = 首行元素顶部 + marginTop → 首行（含 border-top）被整体裁掉
  scrollHeight 不含 padding-bottom → 滚到底最后一行贴死视口底缘

修复后（实测）：
  场景 A：clip 顶部 y=55.625，首行 item 顶部 y=56.625 → 首行 border-top 完整
  场景 B：clip 顶部 y=279.25，child 顶部 y=279.25 → 子元素顶部边框完整
  scrollHeight = 内容高 + paddingBottom（如 1062 = 1048 + 14），
  滚到底 scrollTop + clientHeight == scrollHeight，最后一行完整可见
```

## Cross-Version Impact

- [x] This PR does not change \`common\` contract（新增方法，不改既有公开行为）。
- [ ] This PR changes \`common\` without changing its public contract.
- [ ] This PR changes a \`common\` contract; all affected targets are updated and validated.
- [ ] A target is intentionally not updated; the reason and tracking issue are below.

## Release Notes

common 渲染层修复，所有 target 随 common 生效（Forge/Fabric/NeoForge）：overflow 容器带 margin 时首行内容不再被误裁；带 padding 的滚动容器可完整滚出 padding 空间。建议合入 1.2.1 后续版本。